### PR TITLE
Mark benchmarks as optional library

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,4 @@
 (executables
  (names main mpmc_queue_cmd)
- (libraries lockfree unix yojson))
+ (libraries lockfree unix yojson)
+ (optional))

--- a/lockfree-bench.opam
+++ b/lockfree-bench.opam
@@ -9,14 +9,12 @@ dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
 bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
 tags: []
 depends: [
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "5.0"}
   "dune" {>= "3.0"}
-  "domain_shims" {>= "0.1.0"}
   "qcheck" {with-test & >= "0.18.1"}
-  "qcheck-stm" {with-test & >= "0.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "alcotest" {>= "1.6.0"}
-  "dscheck" {with-test & >= "0.0.1"}
+  "dscheck" {>= "0.0.1"}
+  "yojson" {>= "2.0.2"}
 ]
-depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree-with-bench.opam
+++ b/lockfree-with-bench.opam
@@ -12,9 +12,9 @@ depends: [
   "ocaml" {>= "5.0"}
   "dune" {>= "3.0"}
   "qcheck" {with-test & >= "0.18.1"}
+  "qcheck-stm" {with-test & >= "0.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
-  "alcotest" {>= "1.6.0"}
-  "dscheck" {>= "0.0.1"}
+  "dscheck" {with-test & >= "0.0.1"}
   "yojson" {>= "2.0.2"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree-with-bench.opam
+++ b/lockfree-with-bench.opam
@@ -3,7 +3,7 @@ maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
 authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
 homepage: "https://github.com/ocaml-multicore/lockfree"
 doc: "https://ocaml-multicore.github.io/lockfree"
-synopsis: "Lock-free data structures for multicore OCaml"
+synopsis: "Lock-free data structures for multicore OCaml (with benchmarks)"
 license: "ISC"
 dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
 bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -15,7 +15,7 @@ depends: [
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-stm" {with-test & >= "0.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
-  "alcotest" {>= "1.6.0"}
+  "alcotest" {with-test & >= "1.6.0"}
   "dscheck" {with-test & >= "0.0.1"}
 ]
 depopts: []

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -18,5 +18,7 @@ depends: [
   "alcotest" {>= "1.6.0"}
   "dscheck" {with-test & >= "0.0.1"}
 ]
-depopts: []
+depopts: [
+  "yojson" {>= "2.0.2"}
+]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -16,7 +16,6 @@ depends: [
   "qcheck-stm" {with-test & >= "0.1"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}
   "alcotest" {>= "1.6.0"}
-  "yojson" {>= "2.0.2"}
   "dscheck" {with-test & >= "0.0.1"}
 ]
 depopts: []


### PR DESCRIPTION
This sets benchmarks as optional and puts them into a different new package (which includes yojson dependency).

With this change:
* installing `lockfree` (`opam install ./lockfree.opam --deps-only`) does not install yojson
* pipelines still work as they install all packages in the repo (something like `opam install . --deps-only` I suspect)

I decided to make the benchmarks package a superset of lockfree (so contributor can just install `lockfree-with-benchmarks` to get everything) but I'm happy to do it in a different way if there's a reason. 