### PR TITLE
Lock free hash table

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.23.0
+version = 0.25.1

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 
 A collection of Concurrent Lockfree Data Structures for OCaml 5. It contains:
 
-* [Treiber Stack](src/treiber_stack.mli) A classic multi-producer multi-consumer stack, robust and flexible. Recommended starting point when needing LIFO structure. 
-  
+* [Treiber Stack](src/treiber_stack.mli) A classic multi-producer multi-consumer stack, robust and flexible. Recommended starting point when needing LIFO structure.
+
 * [Michael-Scott Queue](src/michael_scott_queue.mli) A classic multi-producer multi-consumer queue, robust and flexible. Recommended starting point when needing FIFO structure. It is based on [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](https://www.cs.rochester.edu/~scott/papers/1996_PODC_queues.pdf).
 
 * [Chase-Lev Work-Stealing Deque](src/ws_deque.mli) Single-producer, multi-consumer dynamic-size double-ended queue (deque) (see [Dynamic circular work-stealing deque](https://dl.acm.org/doi/10.1145/1073970.1073974) and [Correct and efficient work-stealing for weak memory models](https://dl.acm.org/doi/abs/10.1145/2442516.2442524)). Ideal for throughput-focused scheduling using per-core work distribution. Note, [pop] and [steal] follow different ordering (respectively LIFO and FIFO) and have different linearization contraints.
 
 * [SPSC Queue](src/spsc_queue.mli) Simple single-producer single-consumer fixed-size queue. Thread-safe as long as at most one thread acts as producer and at most one as consumer at any single point in time.
 
-* [MPMC Relaxed Queue](src/mpmc_relaxed_queue.mli) Multi-producer, multi-consumer, fixed-size relaxed queue. Optimised for high number of threads. Not strictly FIFO. Note, it exposes two interfaces: a lockfree and a non-lockfree (albeit more practical) one. See the mli for details. 
+* [MPMC Relaxed Queue](src/mpmc_relaxed_queue.mli) Multi-producer, multi-consumer, fixed-size relaxed queue. Optimised for high number of threads. Not strictly FIFO. Note, it exposes two interfaces: a lockfree and a non-lockfree (albeit more practical) one. See the mli for details.
 
 * [MPSC Queue](src/mpsc_queue.mli) A multi-producer, single-consumer, thread-safe queue without support for cancellation. This makes a good data structure for a scheduler's run queue. It is used in [Eio](https://github.com/ocaml-multicore/eio). It is a single consumer version of the queue described in [Implementing lock-free queues](https://people.cs.pitt.edu/~jacklange/teaching/cs2510-f12/papers/implementing_lock_free.pdf).
+
+* [Hashtable](src/htbl.mli) A domain-safe lock-free hashtable (with a wait-free `mem`). Available in constant-sized and extensible (i.e. resizable up to some constant) variants. The design is based on array and split-ordered list and that allows a particularly fast lookup operation.
 
 ## Usage
 

--- a/bench/dune
+++ b/bench/dune
@@ -1,3 +1,4 @@
 (executables
- (names main mpmc_queue_cmd)
- (libraries lockfree unix yojson))
+ (names main mpmc_queue_cmd hmap)
+ (libraries lockfree unix yojson cmdliner))
+

--- a/bench/hmap.ml
+++ b/bench/hmap.ml
@@ -1,0 +1,147 @@
+module type Interface = sig
+  type 'a t
+  type key = int
+
+  val create : size_exponent:int -> 'a t
+  val add : key -> 'a -> 'a t -> bool
+  val find_opt : key -> 'a t -> 'a option
+  val remove : key -> 'a t -> bool
+end
+
+module Locked : Interface = struct
+  type key = int
+  type 'a t = (key, 'a) Hashtbl.t
+
+  let mutex = Mutex.create ()
+
+  let with_mutex f =
+    Mutex.lock mutex;
+    let v = f () in
+    Mutex.unlock mutex;
+    v
+
+  let create ~size_exponent =
+    let size = Int.shift_left 1 size_exponent in
+    Hashtbl.create size
+
+  let add (k : key) (v : 'a) (t : 'a t) =
+    with_mutex (fun () ->
+        Hashtbl.replace t k v;
+        true)
+
+  let find_opt k t = with_mutex (fun () -> Hashtbl.find_opt t k)
+
+  let remove k t =
+    with_mutex (fun () ->
+        Hashtbl.remove t k;
+        true)
+end
+
+let implementations =
+  [
+    ("locked\t\t\t", (module Locked : Interface));
+    ("lockfree\t\t", (module Lockfree.Hshtbl : Interface));
+    ("lockfree-resizable\t", (module Lockfree.Hshtbl_resizable : Interface));
+  ]
+
+(* module Hashtable = HashtblLocked *)
+module Hashtable = Lockfree.Hshtbl
+
+let run_bench item_count total_domains size_exponent preload_item_count workload
+    (impl_name, implementation) =
+  let module Hashtable = (val implementation : Interface) in
+  Random.init 0;
+
+  let hashtbl = Hashtable.create ~size_exponent in
+  let orchestrator = Orchestrator.init ~total_domains ~rounds:10 in
+
+  let key_range =
+    let size = Int.shift_left 1 size_exponent in
+    max size preload_item_count
+  in
+  for _ = 1 to preload_item_count do
+    Hashtable.add (Random.int key_range) 0 hashtbl |> ignore
+  done;
+
+  (* start domains *)
+  let domains =
+    List.init total_domains (fun _ ->
+        Domain.spawn (fun () ->
+            Orchestrator.worker orchestrator (fun () ->
+                for _ = 1 to item_count do
+                  let key = Random.int key_range in
+                  match workload with
+                  | `Add_remove ->
+                      Hashtable.add key 0 hashtbl |> ignore;
+                      Hashtable.remove key hashtbl |> ignore
+                  | `Get -> Hashtable.find_opt key hashtbl |> ignore
+                done)))
+  in
+  (* run test *)
+  let times = Orchestrator.run orchestrator in
+  List.iter Domain.join domains;
+  let time_median = Stats.median times in
+  let time_stddev = Stats.stddev times in
+  Printf.printf "[%s] time median: %f, stddev: %f\n" impl_name time_median
+    time_stddev
+
+let run item_count domains size_exponent preload_item_count workload =
+  List.iter
+    (run_bench item_count domains size_exponent preload_item_count workload)
+    implementations
+
+open Cmdliner
+
+let preload_item_count =
+  let default = 500 in
+  let info =
+    Arg.info [ "p"; "preload-items" ] ~docv:"INT"
+      ~doc:"Number of items to place in the hashmap before starting benchmark."
+  in
+  Arg.value (Arg.opt Arg.int default info)
+
+let size_exponent =
+  let default = 10 in
+  let info =
+    Arg.info
+      [ "s"; "init-size-exponent" ]
+      ~docv:"INT" ~doc:"Initial size (size = 2^parameter)."
+  in
+  Arg.value (Arg.opt Arg.int default info)
+
+let item_count =
+  let default = 100_000 in
+  let info =
+    Arg.info [ "i"; "item-count" ] ~docv:"INT"
+      ~doc:"Number of items to add and remove."
+  in
+  Arg.value (Arg.opt Arg.int default info)
+
+let domains =
+  let default = 4 in
+  let info =
+    Arg.info [ "d"; "domains" ] ~docv:"INT" ~doc:"Number of domains."
+  in
+  Arg.value (Arg.opt Arg.int default info)
+
+let workload =
+  let default = `Add_remove in
+  let info =
+    Arg.info [ "w"; "workload" ] ~docv:"[add-remove|get]"
+      ~doc:
+        "Workload to bench. The Get option might benefit from combination with \
+         preloading items to create varying hit rates."
+  in
+  Arg.value
+    (Arg.opt
+       (Arg.enum [ ("add-remove", `Add_remove); ("get", `Get) ])
+       default info)
+
+let cmd =
+  let open Term in
+  const run $ item_count $ domains $ size_exponent $ preload_item_count
+  $ workload
+
+let () =
+  exit @@ Cmd.eval
+  @@ Cmd.v (Cmd.info ~doc:"Hashmap Benchmark" "hmap_benchmark") cmd

--- a/bench/orchestrator.ml
+++ b/bench/orchestrator.ml
@@ -13,9 +13,10 @@ let wait_until_all_ready ?(round = 0) { ready; total_domains; _ } =
     ()
   done
 
-let worker ({ ready; round; rounds; _ } as t) f =
+let worker ({ ready; round; rounds; total_domains; _ } as t) f =
   Atomic.incr ready;
   wait_until_all_ready t;
+  assert (Atomic.get ready == total_domains);
   (* all domains are up at this point *)
   for i = 1 to rounds do
     (* wait for signal to start work *)

--- a/lockfree.opam
+++ b/lockfree.opam
@@ -18,6 +18,7 @@ depends: [
   "alcotest" {>= "1.6.0"}
   "yojson" {>= "2.0.2"}
   "dscheck" {with-test & >= "0.0.1"}
+  "cmdliner" {with-test & >= "1.2.0"}
 ]
 depopts: []
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/src/htbl.ml
+++ b/src/htbl.ml
@@ -1,0 +1,354 @@
+(*
+ * Copyright (c) 2023, Carine Morel <carine.morel.pro@gmail.com>
+ *)
+
+module Type = struct
+  type 'b kind = Dummy | Regular of 'b
+  type key = int
+end
+
+module Llist = struct
+  include Type
+
+  type 'a marked = Last | LRemove | Normal of 'a node | Remove of 'a node
+  and 'a node = { key : key; value : 'a kind; next : 'a marked Atomic.t }
+
+  type 'a t = 'a marked Atomic.t
+
+  type 'a local = {
+    prev : 'a marked Atomic.t;
+    curr : 'a marked;
+    next : 'a marked;
+  }
+
+  let init () : 'a t = Atomic.make Last
+
+  let convert_to_normal = function
+    | (Last | Normal _) as node -> node
+    | LRemove -> Last
+    | Remove node -> Normal node
+
+  let mark_to_be_removed = function
+    | Last -> LRemove
+    | Normal node -> Remove node
+    | _ as x -> x
+
+  let rec find_loop key t prev curr =
+    match curr with
+    | Last | LRemove -> (false, { prev; curr; next = Last })
+    | Normal node | Remove node -> (
+        if Atomic.get prev != curr then try_again key t
+        else
+          let next = Atomic.get node.next in
+          match next with
+          | Normal _ | Last ->
+              if node.key >= key then (node.key = key, { prev; curr; next })
+              else find_loop key t node.next next
+          | _ ->
+              let next = convert_to_normal next in
+              if Atomic.compare_and_set prev curr next then
+                find_loop key t prev next
+              else try_again key t)
+
+  and try_again key t = find_loop key t t (Atomic.get t)
+
+  let find key t : bool * 'a local = try_again key t
+
+  let rec unsafe_add (key : key) (value : 'a kind) t : bool * 'a local =
+    let is_found, local = find key t in
+    if is_found then (false, local)
+    else if
+      Atomic.compare_and_set local.prev local.curr
+      @@ Normal { key; next = Atomic.make local.curr; value }
+    then (true, local)
+    else unsafe_add key value t
+
+  let add (key : key) (value : 'a kind) (t : 'a t) =
+    fst (unsafe_add key value t)
+
+  let rec unsafe_remove (key : key) t =
+    let is_found, local = find key t in
+    if not is_found then (false, local)
+    else
+      let curr =
+        match local.curr with
+        | Normal node -> node
+        | _ -> failwith " Should never happen"
+      in
+      if
+        not
+          (Atomic.compare_and_set curr.next local.next
+             (mark_to_be_removed local.next))
+      then unsafe_remove key t
+      else if Atomic.compare_and_set local.prev local.curr local.next then
+        (true, local)
+      else (
+        ignore (find key t);
+        (true, local))
+
+  let remove (key : key) (t : 'a t) = fst (unsafe_remove key t)
+  let mem key t = fst @@ find key t
+end
+
+module Common = struct
+  (* Key value used in the linked list are computed with [reverse] for the
+        dummy node and with [compute_hkey] for the regular node.
+
+     Example of a linked list, simplified to 8 bits integer. Only key
+     are written, as values of regular nodes do not change the linked
+     list order.
+
+      [ 0000 0000 (0, dummy) ]
+     -> [ 0001 0001 (8, regular)]
+     -> [ 0100 0000 (2, dummy)]
+     -> [ 0101 0001 (10, regular)]
+     -> [ 0110 1001 (22, regular)]
+     -> [ 1000 0000 (1, dummy)]
+     -> [ 1000 1001 (17, regular)]
+     -> [ 1100 0000 (3, dummy)]
+  *)
+  let reverse x =
+    (* works for int32 *)
+    let x = x land 0xff_ff_ff_ff in
+    let x = ((x land 0xaa_aa_aa_aa) lsr 1) lor ((x land 0x55_55_55_55) lsl 1) in
+    let x = ((x land 0xcc_cc_cc_cc) lsr 2) lor ((x land 0x33_33_33_33) lsl 2) in
+    let x = ((x land 0xf0_f0_f0_f0) lsr 4) lor ((x land 0x0f_0f_0f_0f) lsl 4) in
+    let x = ((x land 0xff_00_ff_00) lsr 8) lor ((x land 0x00_ff_00_ff) lsl 8) in
+    (x lsr 16) lor (x lsl 16) land 0xffffffff
+
+  let compute_hkey k = reverse k lor 0x00_00_00_01
+
+  (** unset most significant turn on bit (for int32) *)
+  let unset_msb key =
+    let a = key lor (key lsr 1) in
+    let a = a lor (a lsr 2) in
+    let a = a lor (a lsr 4) in
+    let a = a lor (a lsr 8) in
+    let a = a lor (a lsr 16) in
+    (a lsr 1) land key
+
+  let new_dummy_node id llist =
+    let _, local = Llist.unsafe_add (reverse id) Dummy llist in
+    (* If the insertion succeeded ([is_added] = true) then
+       [local.prev] contains the atomic value of the new node.
+
+       If it failed that means another domain has already inserted
+       this dummy node. In this case, [local.prev] also contains the
+       value we seek as the [Llist.find] function calls by
+       [Llist.unsafe_add] will have stopped at the right place. *)
+    Atomic.get local.prev
+end
+
+module Htbl = struct
+  open Common
+  include Type
+
+  type 'a t = { mask : int; buckets : 'a Llist.marked Atomic.t array }
+
+  let init ~size_exponent =
+    let size = Int.shift_left 1 size_exponent in
+    let mask = size - 1 in
+    let llist = Llist.init () in
+    {
+      mask;
+      buckets =
+        Array.init size (fun i ->
+            if i = 0 then Atomic.make (new_dummy_node 0 llist)
+            else Atomic.make Llist.Last);
+    }
+
+  let rec init_bucket buckets ind =
+    let parent_ind = unset_msb ind in
+    let parent_bucket = buckets.(parent_ind) in
+
+    (if parent_ind <> ind then
+     match Atomic.get parent_bucket with
+     | Llist.Last -> init_bucket buckets parent_ind
+     | LRemove -> failwith "Should never happen."
+     | _ -> ());
+
+    new_dummy_node ind parent_bucket |> Atomic.set buckets.(ind)
+
+  (** [get_bucket_id key buckets mask] searches the bucket's index corresponding
+      to [key] (= [key mod t.size]), initializes if needed and returns
+      it. *)
+  let get_bucket_ind key buckets mask =
+    let ind = key land mask in
+    let bucket = buckets.(ind) in
+    match Atomic.get bucket with
+    | Llist.Last ->
+        init_bucket buckets ind;
+        buckets.(ind)
+    | LRemove -> failwith "Should never happen."
+    | _ -> bucket
+
+  (** [add key value t] *)
+  let add key value { buckets; mask; _ } =
+    Llist.add (compute_hkey key) (Regular value)
+    @@ get_bucket_ind key buckets mask
+
+  let find key { buckets; mask; _ } =
+    let is_found, local =
+      Llist.find (compute_hkey key) (get_bucket_ind key buckets mask)
+    in
+    if not is_found then None
+    else
+      match local.curr with
+      | Normal { value = Regular k; _ } | Remove { value = Regular k; _ } ->
+          Some k
+      | _ -> failwith "Should not happen"
+
+  let mem key { buckets; mask; _ } =
+    fst @@ Llist.find (compute_hkey key) (get_bucket_ind key buckets mask)
+
+  let remove key { buckets; mask; _ } =
+    Llist.remove (compute_hkey key) (get_bucket_ind key buckets mask)
+end
+
+module Htbl_resizable = struct
+  open Common
+  include Type
+
+  (* pointers to a node in linked list *)
+  type 'a bucket = 'a Llist.marked Atomic.t
+  type 'a segment = 'a bucket array
+
+  type 'a t = {
+    (* total item count *)
+    count : int Atomic.t;
+    (* current number of segments *)
+    number_of_buckets : int Atomic.t;
+    (* maximum number of items in a bucket (on average).  Maximun
+       number of elements in an hash table [t] is [t.sizes] * [t.max] *)
+    max : int;
+    segments : 'a segment option Atomic.t array;
+    max_number_of_buckets : int;
+    segment_size : int;
+  }
+
+  let init ~size_exponent =
+    let max = 2 in
+    let grow_exp = 10 in
+    let llist = Llist.init () in
+
+    let segment_size = Int.shift_left 1 size_exponent in
+
+    let exp_max = grow_exp + size_exponent in
+    let max_number_of_buckets = Int.shift_left 1 exp_max in
+
+    let first_seg =
+      Array.init segment_size (fun i ->
+          if i = 0 then Atomic.make (new_dummy_node 0 llist)
+          else Atomic.make Llist.Last)
+    in
+
+    let segments =
+      Array.init (Int.shift_left 1 grow_exp) (fun i ->
+          match i with
+          | 0 -> Atomic.make (Some first_seg)
+          | _ -> Atomic.make None)
+    in
+    {
+      count = Atomic.make 0;
+      number_of_buckets = Atomic.make segment_size;
+      segment_size;
+      max_number_of_buckets;
+      segments;
+      max;
+    }
+
+  let is_empty { count; _ } = Atomic.get count = 0
+
+  let get_segment t segment_ind =
+    let seg = t.segments.(segment_ind) in
+    match Atomic.get seg with
+    | Some seg -> seg
+    | None ->
+        (* Can failed if another domain has already done it *)
+        Atomic.compare_and_set seg None
+          (Some (Array.init t.segment_size (fun _ -> Atomic.make Llist.Last)))
+        |> ignore;
+        (* always true as either this domain or another just changed
+           the value of this cell and the only values written in
+           [t.segments] are `Some` values *)
+        Option.get (Atomic.get seg)
+
+  let get_bucket_ref t ind =
+    let segment_ind = ind / t.segment_size in
+    let segment = get_segment t segment_ind in
+    segment.(ind land (t.segment_size - 1))
+
+  (** [init_bucket buckets ind] inits a bucket and all its parents if needed *)
+  let rec init_bucket t bucket bucket_ind =
+    let parent_ind = unset_msb bucket_ind in
+    let parent_bucket = get_bucket_ref t parent_ind in
+    (if parent_ind <> bucket_ind then
+     match Atomic.get parent_bucket with
+     | Llist.Last -> init_bucket t parent_bucket parent_ind
+     | LRemove -> failwith "Should never happen"
+     | _ -> ());
+    new_dummy_node bucket_ind parent_bucket |> Atomic.set bucket
+
+  let get_bucket key t =
+    let mask_val = Atomic.get t.number_of_buckets - 1 in
+    let bucket_ind = key land mask_val in
+    let bucket = get_bucket_ref t bucket_ind in
+    match Atomic.get bucket with
+    | Llist.Last ->
+        init_bucket t bucket bucket_ind;
+        bucket
+    | LRemove -> failwith "Should never happen"
+    | _ -> bucket
+
+  let rec grow ({ number_of_buckets; max_number_of_buckets; max; _ } as t) count
+      =
+    let number_of_buckets_val = Atomic.get number_of_buckets in
+    if
+      count > number_of_buckets_val * max
+      && number_of_buckets_val < max_number_of_buckets
+    then
+      if
+        Atomic.compare_and_set t.number_of_buckets number_of_buckets_val
+          (number_of_buckets_val lsl 1)
+      then ()
+      else grow t count
+
+  (** [add key value t] *)
+  let add (key : key) (value : 'a) (t : 'a t) =
+    let is_added =
+      Llist.add (compute_hkey key) (Regular value) @@ get_bucket key t
+    in
+    if not is_added then false
+    else (
+      Atomic.fetch_and_add t.count 1 |> grow t;
+      true)
+
+  let add_no_resize key value t =
+    let is_added =
+      Llist.add (compute_hkey key) (Regular value) @@ get_bucket key t
+    in
+    if not is_added then false
+    else (
+      Atomic.incr t.count;
+      true)
+
+  let find key t =
+    let is_found, local = Llist.find (compute_hkey key) (get_bucket key t) in
+    if not is_found then None
+    else
+      match local.curr with
+      | Normal { value = Regular k; _ } | Remove { value = Regular k; _ } ->
+          Some k
+      | _ -> failwith "Should not happen"
+
+  let mem key t =
+    let is_found, _ = Llist.find (compute_hkey key) (get_bucket key t) in
+    is_found
+
+  let remove key t =
+    let is_removed = Llist.remove (compute_hkey key) (get_bucket key t) in
+    if not is_removed then false
+    else (
+      Atomic.decr t.count;
+      true)
+end

--- a/src/htbl.mli
+++ b/src/htbl.mli
@@ -1,0 +1,34 @@
+module Llist : sig
+  type 'a t
+  type key = int
+  type 'a kind = Dummy | Regular of 'a
+
+  val init : unit -> 'a t
+  val add : key -> 'a kind -> 'a t -> bool
+  val remove : key -> 'a t -> bool
+  val mem : key -> 'a t -> bool
+end
+
+module Htbl : sig
+  type 'a t
+  type key = int
+
+  val init : size_exponent:int -> 'a t
+  val add : key -> 'a -> 'a t -> bool
+  val find : key -> 'a t -> 'a option
+  val mem : key -> 'a t -> bool
+  val remove : key -> 'a t -> bool
+end
+
+module Htbl_resizable : sig
+  type 'a t
+  type key = int
+
+  val init : size_exponent:int -> 'a t
+  val add : key -> 'a -> 'a t -> bool
+  val add_no_resize : int -> 'a -> 'a t -> bool
+  val find : key -> 'a t -> 'a option
+  val mem : key -> 'a t -> bool
+  val remove : key -> 'a t -> bool
+  val is_empty : 'a t -> bool
+end

--- a/src/htbl.mli
+++ b/src/htbl.mli
@@ -35,3 +35,30 @@ module Htbl_resizable : sig
   val remove : key -> 'a t -> bool
   val is_empty : 'a t -> bool
 end
+
+(*
+            let rec find_loop key t prev curr_mkr =
+    match curr_mkr with
+    | Last | LRemove -> (false, { prev; curr = curr_mkr; next = Last })
+    | Normal curr | Remove curr ->
+        let rec snip_loop curr_key curr_mrk next_ptr =
+          let next_mrk = Atomic.get next_ptr in
+          match next_mrk with
+          | (Normal _ | Last) when curr_key >= key ->
+              (curr_key = key, { prev; curr = curr_mkr; next = next_mrk })
+          | Normal _ -> find_loop key t next_ptr next_mrk
+          | Last -> (false, { prev = next_ptr; curr = next_mrk; next = Last })
+          | Remove next ->
+              let new_curr = Normal next in
+              if not @@ Atomic.compare_and_set prev curr_mrk new_curr then
+                try_again key t
+              else
+                (*find_loop key t prev (Normal new_curr)*)
+                snip_loop curr_key new_curr next.next
+          | LRemove ->
+              if not @@ Atomic.compare_and_set prev curr_mkr Last then
+                try_again key t
+              else (false, { prev; curr = next_mrk; next = Last })
+        in
+        snip_loop curr.key curr_mkr curr.next
+        *)

--- a/src/htbl.mli
+++ b/src/htbl.mli
@@ -5,6 +5,7 @@ module Llist : sig
 
   val init : unit -> 'a t
   val add : key -> 'a kind -> 'a t -> bool
+  val replace : key -> 'a kind -> 'a t -> [ `Replaced | `Added ]
   val remove : key -> 'a t -> bool
   val mem : key -> 'a t -> bool
 end
@@ -15,6 +16,7 @@ module Htbl : sig
 
   val init : size_exponent:int -> 'a t
   val add : key -> 'a -> 'a t -> bool
+  val replace : key -> 'a -> 'a t -> unit
   val find : key -> 'a t -> 'a option
   val mem : key -> 'a t -> bool
   val remove : key -> 'a t -> bool
@@ -26,6 +28,7 @@ module Htbl_resizable : sig
 
   val init : size_exponent:int -> 'a t
   val add : key -> 'a -> 'a t -> bool
+  val replace : key -> 'a -> 'a t -> unit
   val add_no_resize : int -> 'a -> 'a t -> bool
   val find : key -> 'a t -> 'a option
   val mem : key -> 'a t -> bool

--- a/src/lockfree.ml
+++ b/src/lockfree.ml
@@ -32,3 +32,5 @@ module Treiber_stack = Treiber_stack
 module Michael_scott_queue = Michael_scott_queue
 module Backoff = Backoff
 module Mpmc_relaxed_queue = Mpmc_relaxed_queue
+module Hshtbl = Htbl.Htbl
+module Hshtbl_resizable = Htbl.Htbl_resizable

--- a/src/lockfree.mli
+++ b/src/lockfree.mli
@@ -36,4 +36,6 @@ module Mpsc_queue = Mpsc_queue
 module Treiber_stack = Treiber_stack
 module Michael_scott_queue = Michael_scott_queue
 module Mpmc_relaxed_queue = Mpmc_relaxed_queue
+module Hshtbl = Htbl.Htbl
+module Hshtbl_resizable = Htbl.Htbl_resizable
 module Backoff = Backoff

--- a/test/hshtbl/dune
+++ b/test/hshtbl/dune
@@ -1,0 +1,46 @@
+(rule
+ (copy ../../src/htbl.ml htbl.ml))
+
+(rule
+ (copy ../../src/htbl.ml htbl_resizable.ml))
+
+(test
+ (name htbl_dscheck)
+ (libraries atomic dscheck alcotest)
+ (modules htbl htbl_dscheck))
+
+(test
+ (name htbl_resizable_dscheck)
+ (libraries atomic dscheck alcotest)
+ (modules htbl_resizable htbl_resizable_dscheck))
+
+(test
+ (name qcheck_llist)
+ (libraries lockfree qcheck qcheck-alcotest)
+ (modules qcheck_llist))
+
+(test
+ (name qcheck_htbl)
+ (libraries lockfree qcheck qcheck-alcotest)
+ (modules qcheck_htbl))
+
+(test
+ (name stm_llist)
+ (modules stm_llist)
+ (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (action
+  (run %{test} --verbose)))
+
+(test
+ (name stm_htbl)
+ (modules stm_htbl)
+ (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (action
+  (run %{test} --verbose)))
+
+(test
+ (name stm_htbl_resizable)
+ (modules stm_htbl_resizable)
+ (libraries lockfree qcheck-stm.sequential qcheck-stm.domain)
+ (action
+  (run %{test} --verbose)))

--- a/test/hshtbl/dune
+++ b/test/hshtbl/dune
@@ -4,6 +4,9 @@
 (rule
  (copy ../../src/htbl.ml htbl_resizable.ml))
 
+(rule
+ (copy ../../src/htbl.ml llist.ml))
+
 (test
  (name htbl_dscheck)
  (libraries atomic dscheck alcotest)
@@ -13,6 +16,11 @@
  (name htbl_resizable_dscheck)
  (libraries atomic dscheck alcotest)
  (modules htbl_resizable htbl_resizable_dscheck))
+
+(test
+ (name llist_dscheck)
+ (libraries atomic dscheck alcotest)
+ (modules llist llist_dscheck))
 
 (test
  (name qcheck_llist)

--- a/test/hshtbl/htbl_dscheck.ml
+++ b/test/hshtbl/htbl_dscheck.ml
@@ -2,7 +2,7 @@ module Htbl = Htbl.Htbl
 
 let two_domains_add () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let item1 = [ 0; 1; 2 ] in
       let item2 = [ 3; 4; 1 ] in
 
@@ -16,15 +16,19 @@ let two_domains_add () =
           Atomic.check (fun () ->
               List.for_all
                 (fun i ->
-                  match Htbl.find i htbl with None -> false | Some j -> i = j)
+                  match Htbl.find_opt i htbl with
+                  | None -> false
+                  | Some j -> i = j)
                 (item1 @ item2))))
 
 let two_domains_replace () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let item1 = [ (0, "a"); (1, "b"); (2, "c") ] in
       let item2 = [ (0, "d"); (4, "e"); (1, "f") ] in
-      let append = List.sort_uniq (fun (k, _) (k', _) -> compare k k') (item1 @ item2) in
+      let append =
+        List.sort_uniq (fun (k, _) (k', _) -> compare k k') (item1 @ item2)
+      in
 
       Atomic.spawn (fun () ->
           List.iter (fun (k, v) -> Htbl.replace k v htbl) item1);
@@ -36,7 +40,7 @@ let two_domains_replace () =
           Atomic.check (fun () ->
               List.for_all
                 (fun (k, _) ->
-                  match Htbl.find k htbl with
+                  match Htbl.find_opt k htbl with
                   | None -> false
                   | Some v -> (
                       match
@@ -45,11 +49,11 @@ let two_domains_replace () =
                       | None, Some v' | Some v', None -> v = v'
                       | Some v1, Some v2 -> v = v1 || v = v2
                       | None, None -> false))
-              append)))
+                append)))
 
 let two_domains_remove () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let items = [ 0; 1; 2; 3 ] in
       let res1 = ref [] in
       let res2 = ref [] in
@@ -75,7 +79,7 @@ let two_domains_remove () =
 
 let two_domains_remove_bis () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let items = [ 0; 1; 2; 3 ] in
       let to_remove = [ 0; 0; 1; 1 ] in
       let res1 = ref [] in
@@ -104,7 +108,7 @@ let two_domains_remove_bis () =
 
 let two_domains_add_remove () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:3 in
+      let htbl = Htbl.create ~size_exponent:3 in
       let items_seq = [ 0; 1; 2 ] in
       let to_add = [ 4; 5; 6 ] in
       let to_remove = [ 5; 0; 4; 10 ] in

--- a/test/hshtbl/htbl_dscheck.ml
+++ b/test/hshtbl/htbl_dscheck.ml
@@ -1,0 +1,114 @@
+module Htbl = Htbl.Htbl
+
+let two_domains_add () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let item1 = [ 0; 1; 2 ] in
+      let item2 = [ 3; 4; 1 ] in
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) item1);
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) item2);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun i -> Htbl.mem i htbl) (item1 @ item2))))
+
+let two_domains_remove () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let items = [ 0; 1; 2; 3 ] in
+      let res1 = ref [] in
+      let res2 = ref [] in
+
+      (* Initialization*)
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) items;
+
+      let remove_all items = List.map (fun elt -> Htbl.remove elt htbl) items in
+
+      Atomic.spawn (fun () -> res1 := remove_all items);
+      Atomic.spawn (fun () -> res2 := remove_all items);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun elt -> Htbl.mem elt htbl |> not) items);
+
+          Atomic.check (fun () ->
+              List.for_all2
+                (fun removed_by_1 removed_by_2 ->
+                  (removed_by_1 && not removed_by_2)
+                  || (removed_by_2 && not removed_by_1))
+                !res1 !res2)))
+
+let two_domains_remove_bis () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let items = [ 0; 1; 2; 3 ] in
+      let to_remove = [ 0; 0; 1; 1 ] in
+      let res1 = ref [] in
+      let res2 = ref [] in
+
+      (* Initialization*)
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) items;
+
+      let remove_all items = List.map (fun elt -> Htbl.remove elt htbl) items in
+
+      Atomic.spawn (fun () -> res1 := remove_all to_remove);
+      Atomic.spawn (fun () -> res2 := remove_all to_remove);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun elt -> Htbl.mem elt htbl |> not) to_remove);
+
+          Atomic.check (fun () ->
+              match (!res1, !res2) with
+              | [ true; false; true; false ], [ false; false; false; false ]
+              | [ false; false; false; false ], [ true; false; true; false ]
+              | [ true; false; false; false ], [ false; false; true; false ]
+              | [ false; false; true; false ], [ true; false; false; false ] ->
+                  true
+              | _ -> false)))
+
+let two_domains_add_remove () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:3 in
+      let items_seq = [ 0; 1; 2 ] in
+      let to_add = [ 4; 5; 6 ] in
+      let to_remove = [ 5; 0; 4; 10 ] in
+
+      (* Sequential adds *)
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) items_seq;
+
+      let removed = ref [] in
+      let added = ref [] in
+      Atomic.spawn (fun () ->
+          removed := List.map (fun elt -> (elt, Htbl.remove elt htbl)) to_remove);
+
+      Atomic.spawn (fun () ->
+          added := List.map (fun elt -> Htbl.add elt elt htbl) to_add);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () -> List.for_all (fun elt -> elt) !added);
+          Atomic.check (fun () ->
+              List.for_all
+                (fun key ->
+                  if List.mem key to_remove then
+                    let is_removed = List.assoc key !removed in
+                    is_removed = not @@ Htbl.mem key htbl
+                  else Htbl.mem key htbl)
+                (items_seq @ to_add))))
+
+let () =
+  let open Alcotest in
+  run "hshtbl_dscheck"
+    [
+      ( "basic",
+        [
+          test_case "2-domains_add" `Slow two_domains_add;
+          test_case "2-domains_remove" `Slow two_domains_remove;
+          test_case "2-domains_remove_bis" `Slow two_domains_remove_bis;
+          test_case "2-domains_add_remove" `Slow two_domains_add_remove;
+        ] );
+    ]

--- a/test/hshtbl/htbl_resizable_dscheck.ml
+++ b/test/hshtbl/htbl_resizable_dscheck.ml
@@ -2,7 +2,7 @@ module Htbl = Htbl_resizable.Htbl_resizable
 
 let two_domains_add () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let item1 = [ 0; 1 ] in
       let item2 = [ 3; 4; 1 ] in
 
@@ -18,7 +18,7 @@ let two_domains_add () =
 
 let two_domains_add_resize () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:1 in
+      let htbl = Htbl.create ~size_exponent:1 in
       let item_seq = [ 6; 7 ] in
       let item1 = [ 0; 1; 2 ] in
       let item2 = [ 3; 4; 5 ] in
@@ -37,10 +37,12 @@ let two_domains_add_resize () =
 
 let two_domains_replace () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let item1 = [ (0, "a"); (1, "b"); (2, "c") ] in
       let item2 = [ (0, "d"); (4, "e"); (1, "f") ] in
-      let append = List.sort_uniq (fun (k, _) (k', _) -> compare k k') (item1 @ item2) in
+      let append =
+        List.sort_uniq (fun (k, _) (k', _) -> compare k k') (item1 @ item2)
+      in
 
       Atomic.spawn (fun () ->
           List.iter (fun (k, v) -> Htbl.replace k v htbl) item1);
@@ -52,7 +54,7 @@ let two_domains_replace () =
           Atomic.check (fun () ->
               List.for_all
                 (fun (k, _) ->
-                  match Htbl.find k htbl with
+                  match Htbl.find_opt k htbl with
                   | None -> false
                   | Some v -> (
                       match
@@ -61,11 +63,11 @@ let two_domains_replace () =
                       | None, Some v' | Some v', None -> v = v'
                       | Some v1, Some v2 -> v = v1 || v = v2
                       | None, None -> false))
-              append)))
+                append)))
 
 let two_domains_remove () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:2 in
+      let htbl = Htbl.create ~size_exponent:2 in
       let items = [ 0; 1; 2 ] in
       let res1 = ref [] in
       let res2 = ref [] in
@@ -91,7 +93,7 @@ let two_domains_remove () =
 
 let two_domains_add_remove () =
   Atomic.trace (fun () ->
-      let htbl = Htbl.init ~size_exponent:3 in
+      let htbl = Htbl.create ~size_exponent:3 in
       let items_seq = [ 0; 1; 2 ] in
       let to_add = [ 4; 5; 6 ] in
       let to_remove = [ 5; 0; 4; 10 ] in

--- a/test/hshtbl/htbl_resizable_dscheck.ml
+++ b/test/hshtbl/htbl_resizable_dscheck.ml
@@ -1,0 +1,104 @@
+module Htbl = Htbl_resizable.Htbl_resizable
+
+let two_domains_add () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let item1 = [ 0; 1 ] in
+      let item2 = [ 3; 4; 1 ] in
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add_no_resize elt elt htbl |> ignore) item1);
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add_no_resize elt elt htbl |> ignore) item2);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun i -> Htbl.mem i htbl) (item1 @ item2))))
+
+let two_domains_add_resize () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:1 in
+      let item_seq = [ 6; 7 ] in
+      let item1 = [ 0; 1; 2 ] in
+      let item2 = [ 3; 4; 5 ] in
+
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) item_seq;
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) item1);
+
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) item2);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun i -> Htbl.mem i htbl) (item_seq @ item1 @ item2))))
+
+let two_domains_remove () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let items = [ 0; 1; 2 ] in
+      let res1 = ref [] in
+      let res2 = ref [] in
+
+      (* Initialization*)
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) items;
+
+      let remove_all items = List.map (fun elt -> Htbl.remove elt htbl) items in
+
+      Atomic.spawn (fun () -> res1 := remove_all items);
+      Atomic.spawn (fun () -> res2 := remove_all items);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun elt -> Htbl.mem elt htbl |> not) items);
+
+          Atomic.check (fun () ->
+              List.for_all2
+                (fun removed_by_1 removed_by_2 ->
+                  (removed_by_1 && not removed_by_2)
+                  || (removed_by_2 && not removed_by_1))
+                !res1 !res2)))
+
+let two_domains_add_remove () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:3 in
+      let items_seq = [ 0; 1; 2 ] in
+      let to_add = [ 4; 5; 6 ] in
+      let to_remove = [ 5; 0; 4; 10 ] in
+
+      (* Sequential adds *)
+      List.iter (fun elt -> Htbl.add elt elt htbl |> ignore) items_seq;
+
+      let removed = ref [] in
+      let added = ref [] in
+      Atomic.spawn (fun () ->
+          removed := List.map (fun elt -> (elt, Htbl.remove elt htbl)) to_remove);
+
+      Atomic.spawn (fun () ->
+          added := List.map (fun elt -> Htbl.add elt elt htbl) to_add);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () -> List.for_all (fun elt -> elt) !added);
+          Atomic.check (fun () ->
+              List.for_all
+                (fun key ->
+                  if List.mem key to_remove then
+                    let is_removed = List.assoc key !removed in
+                    is_removed = not @@ Htbl.mem key htbl
+                  else Htbl.mem key htbl)
+                (items_seq @ to_add))))
+
+let () =
+  let open Alcotest in
+  run "hshtbl_resizable_dscheck"
+    [
+      ( "basic",
+        [
+          test_case "2-domains_add" `Slow two_domains_add;
+          test_case "2-domains_add_resize" `Slow two_domains_add_resize;
+          test_case "2-domains_remove" `Slow two_domains_remove;
+          test_case "2-domains_add_remove" `Slow two_domains_add_remove;
+        ] );
+    ]

--- a/test/hshtbl/htbl_resizable_dscheck.ml
+++ b/test/hshtbl/htbl_resizable_dscheck.ml
@@ -35,6 +35,34 @@ let two_domains_add_resize () =
           Atomic.check (fun () ->
               List.for_all (fun i -> Htbl.mem i htbl) (item_seq @ item1 @ item2))))
 
+let two_domains_replace () =
+  Atomic.trace (fun () ->
+      let htbl = Htbl.init ~size_exponent:2 in
+      let item1 = [ (0, "a"); (1, "b"); (2, "c") ] in
+      let item2 = [ (0, "d"); (4, "e"); (1, "f") ] in
+      let append = List.sort_uniq (fun (k, _) (k', _) -> compare k k') (item1 @ item2) in
+
+      Atomic.spawn (fun () ->
+          List.iter (fun (k, v) -> Htbl.replace k v htbl) item1);
+
+      Atomic.spawn (fun () ->
+          List.iter (fun (k, v) -> Htbl.replace k v htbl) item2);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all
+                (fun (k, _) ->
+                  match Htbl.find k htbl with
+                  | None -> false
+                  | Some v -> (
+                      match
+                        (List.assoc_opt k item1, List.assoc_opt k item2)
+                      with
+                      | None, Some v' | Some v', None -> v = v'
+                      | Some v1, Some v2 -> v = v1 || v = v2
+                      | None, None -> false))
+              append)))
+
 let two_domains_remove () =
   Atomic.trace (fun () ->
       let htbl = Htbl.init ~size_exponent:2 in
@@ -97,6 +125,7 @@ let () =
       ( "basic",
         [
           test_case "2-domains_add" `Slow two_domains_add;
+          test_case "2-domains_replace" `Slow two_domains_replace;
           test_case "2-domains_add_resize" `Slow two_domains_add_resize;
           test_case "2-domains_remove" `Slow two_domains_remove;
           test_case "2-domains_add_remove" `Slow two_domains_add_remove;

--- a/test/hshtbl/llist_dscheck.ml
+++ b/test/hshtbl/llist_dscheck.ml
@@ -2,7 +2,7 @@ module Llist = Llist.Llist
 
 let two_domains_remove_add () =
   Atomic.trace (fun () ->
-      let l = Llist.init () in
+      let l = Llist.create () in
       let item = [ 0; 1; 3; 4 ] in
 
       List.iter (fun elt -> Llist.add elt Llist.Dummy l |> ignore) item;
@@ -19,7 +19,7 @@ let two_domains_remove_add () =
 
 let two_domains_remove_same () =
   Atomic.trace (fun () ->
-      let l = Llist.init () in
+      let l = Llist.create () in
       let item = [ 0; 1; 3; 4 ] in
       let removed1, removed2 = (ref false, ref false) in
 
@@ -38,7 +38,7 @@ let two_domains_remove_same () =
 let two_domains_add_remove_same () =
   Atomic.trace (fun () ->
       Random.init 0;
-      let l = Llist.init () in
+      let l = Llist.create () in
       let nelt = 3 in
       let item_seq = List.init nelt (fun i -> i * 2) in
       let item_par =

--- a/test/hshtbl/llist_dscheck.ml
+++ b/test/hshtbl/llist_dscheck.ml
@@ -1,0 +1,91 @@
+module Llist = Llist.Llist
+
+let two_domains_remove_add () =
+  Atomic.trace (fun () ->
+      let l = Llist.init () in
+      let item = [ 0; 1; 3; 4 ] in
+
+      List.iter (fun elt -> Llist.add elt Llist.Dummy l |> ignore) item;
+
+      Atomic.spawn (fun () ->
+          Llist.remove 1 l |> ignore;
+          Llist.remove 3 l |> ignore);
+
+      Atomic.spawn (fun () -> Llist.add 2 Llist.Dummy l |> ignore);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              Llist.mem 0 l && Llist.mem 2 l && Llist.mem 4 l)))
+
+let two_domains_remove_same () =
+  Atomic.trace (fun () ->
+      let l = Llist.init () in
+      let item = [ 0; 1; 3; 4 ] in
+      let removed1, removed2 = (ref false, ref false) in
+
+      List.iter (fun elt -> Llist.add elt Llist.Dummy l |> ignore) item;
+
+      Atomic.spawn (fun () -> removed1 := Llist.remove 3 l);
+
+      Atomic.spawn (fun () -> removed2 := Llist.remove 3 l);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              List.for_all (fun elt -> Llist.mem elt l) [ 0; 1; 4 ]
+              && (not @@ Llist.mem 3 l)
+              && ((!removed1 && not !removed2) || (!removed2 && not !removed1)))))
+
+let two_domains_add_remove_same () =
+  Atomic.trace (fun () ->
+      Random.init 0;
+      let l = Llist.init () in
+      let nelt = 3 in
+      let item_seq = List.init nelt (fun i -> i * 2) in
+      let item_par =
+        (* all elements are only once in the list *)
+        List.init nelt (fun _i -> Random.int (nelt * 3))
+        |> List.fold_left
+             (fun acc elt -> if List.mem elt acc then acc else elt :: acc)
+             []
+      in
+      let added = ref [] in
+      let removed = ref [] in
+
+      List.iter (fun elt -> Llist.add elt Llist.Dummy l |> ignore) item_seq;
+
+      Atomic.spawn (fun () ->
+          List.iter
+            (fun elt -> added := Llist.add elt Llist.Dummy l :: !added)
+            item_par);
+
+      Atomic.spawn (fun () ->
+          List.iter
+            (fun elt -> removed := Llist.remove elt l :: !removed)
+            item_par);
+
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              let res = List.combine !added !removed |> List.rev in
+              List.for_all2
+                (fun elt (added, removed) ->
+                  match (List.mem elt item_seq, added, removed) with
+                  | true, false, true | false, false, false | false, true, true
+                    ->
+                      not @@ Llist.mem elt l
+                  | false, true, false -> Llist.mem elt l
+                  | true, true, true -> true
+                  | _, _, _ -> false)
+                item_par res)))
+
+let () =
+  let open Alcotest in
+  run "hshtbl_dscheck"
+    [
+      ( "basic",
+        [
+          test_case "2-domains_remove_add" `Slow two_domains_remove_add;
+          test_case "2-domains_remove_same" `Slow two_domains_remove_same;
+          test_case "2-domains_add_remove_same" `Slow
+            two_domains_add_remove_same;
+        ] );
+    ]

--- a/test/hshtbl/qcheck_htbl.ml
+++ b/test/hshtbl/qcheck_htbl.ml
@@ -1,0 +1,275 @@
+module Htbl = Lockfree.Hshtbl_resizable
+
+(* making sure the generation int list are small enough (small_nat < 100) *)
+let nat_list = QCheck.(list_of_size Gen.small_nat small_nat)
+let nat_int_list = QCheck.(list_of_size Gen.small_nat (pair small_nat int))
+
+let count = 10_000
+
+(* this function makes sure that all pairs in [l1] and [l2] have a
+   different key without sorting the lists.
+
+   We want to avoid sorting the list as the linked list below the hash
+   table is sorted and adding sorted elements might avoid some bugs.
+
+   The maximun key value of l1 is added to all keys of l2 to create
+   new unique keys and avoid reducing the lists to much
+*)
+let avoid_dup_keys l1 l2 =
+  let max_l1, l1_uniq =
+    List.fold_left
+      (fun (m, acc) (k, v) ->
+        if List.mem_assoc k acc then (m, acc) else (max m k, (k, v) :: acc))
+      (0, []) l1
+  in
+  let l2_uniq =
+    List.fold_left
+      (fun acc (k, v) -> if List.mem_assoc k acc then acc else (k, v) :: acc)
+      [] l2
+    |> List.map (fun (k, v) -> (k + max_l1 + 1, v))
+  in
+  (l1_uniq, l2_uniq)
+
+let tests_one_domain =
+  QCheck.
+    [
+      (* Add a list of unique elements in a linked list. All
+         insertion should success. *)
+      Test.make ~count ~name:"seq_add" nat_int_list (fun l ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+          let l = List.sort_uniq (fun (a, _) (b, _) -> compare a b) l in
+          List.for_all (fun (k, v) -> add k v t) l);
+      (* Add a list of elements in a linked list and checks :
+
+         - the elements that have already been added, the [add]
+         function returns [false] and [true] otherwise.
+
+         - [mem] on all added elements returns [true].
+      *)
+      Test.make ~count ~name:"seq_add_mem" nat_int_list (fun l ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+
+          let has_been_added = List.map (fun (k, v) -> add k v t) l in
+
+          let rec loop prev l has_been_added =
+            match (l, has_been_added) with
+            | [], [] -> true
+            | [], _ | _, [] -> false
+            | (k, _) :: xs, added :: has_been_added ->
+                if added = not (List.mem k prev) then
+                  loop (k :: prev) xs has_been_added
+                else false
+          in
+
+          loop [] l has_been_added
+          &&
+          let uniq = List.sort (fun (a, _) (b, _) -> compare a b) l in
+          List.for_all (fun (k, _) -> mem k t) uniq);
+      (* Add a list of elements and then remove then. Tested properties are :
+         - added and removed elements are the same
+         - mem on all elements return false
+      *)
+      Test.make ~count ~name:"seq_remove" nat_int_list (fun l ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+
+          let has_been_added = List.map (fun (k, v) -> add k v t) l in
+          let has_been_removed = List.map (fun (k, _) -> remove k t) l in
+
+          (* Tested properties *)
+          has_been_added = has_been_removed
+          && List.for_all (fun (k, _) -> not (mem k t)) l);
+      (* Add a list of elements and then search random keys.
+         This test checks that
+         forall k, l,  List.assoc_opt k l = Htbl.find k t
+         where t = List.iter (fun (k, v) -> Htbl.add k v t |> ignore) l (Htbl.init ~size_exponent:n)
+      *)
+      Test.make ~count ~name:"seq_find" (pair nat_int_list nat_list)
+        (fun (to_add, to_search_for) ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+
+          List.iter (fun (k, v) -> add k v t |> ignore) to_add;
+          let found = List.map (fun k -> find k t) to_search_for in
+
+          (* Tested properties *)
+          List.for_all2
+            (fun k found -> List.assoc_opt k to_add = found)
+            to_search_for found);
+      (* Add a list of elements and then search for then.
+      *)
+      Test.make ~count ~name:"seq_find2" nat_int_list (fun l ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+
+          let has_been_added = List.map (fun (k, v) -> add k v t) l in
+          let should_be_found = List.map (fun (k, _) -> find k t) l in
+          let res = List.combine has_been_added should_be_found in
+
+          (* Tested properties *)
+          List.for_all2
+            (fun (k, v) (added, found) ->
+              match (added, found) with
+              | true, Some r -> r = v
+              | false, Some r ->
+                  List.assoc_opt k l = Some r
+                  (* if adding the element did not work, that means
+                     the key is already used *)
+              | _, _ -> false)
+            l res
+          && List.for_all Option.is_some should_be_found);
+    ]
+
+let tests_two_domain =
+  QCheck.
+    [
+      (* Two domains add elements that all have a different key. The
+         tested properties is that no element is missing at the
+         end. *)
+      Test.make ~count ~name:"par_add" (pair nat_int_list nat_int_list)
+        (fun (l1, l2) ->
+          let l1, l2 = avoid_dup_keys l1 l2 in
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+          let sema = Semaphore.Binary.make false in
+
+          let domain2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.map
+                  (fun (k, v) ->
+                    Domain.cpu_relax ();
+                    add k v t)
+                  l2)
+          in
+
+          (* make sure the other domain has begun *)
+          while not (Semaphore.Binary.try_acquire sema) do
+            Domain.cpu_relax ()
+          done;
+
+          let added_by_d1 =
+            List.map
+              (fun (k, v) ->
+                Domain.cpu_relax ();
+                add k v t)
+              l1
+          in
+          let added_by_d2 = Domain.join domain2 in
+
+          (* test properties : all elt have been added and can be sequentially found *)
+          List.for_all (fun a -> a) added_by_d1
+          && List.for_all (fun a -> a) added_by_d2
+          && List.for_all (fun (k, v) -> find k t = Some v) l1
+          && List.for_all (fun (k, v) -> find k t = Some v) l2);
+      (* Parallel removal of elements in a sequentially build hash table. *)
+      Test.make ~count ~name:"par_remove" nat_int_list (fun to_add ->
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+          let sema = Semaphore.Binary.make false in
+          let added = List.map (fun (k, v) -> add k v t) to_add in
+
+          let domain2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.map
+                  (fun (k, _v) ->
+                    Domain.cpu_relax ();
+                    remove k t)
+                  to_add)
+          in
+
+          (* make sure the other domain has begun *)
+          while not (Semaphore.Binary.try_acquire sema) do
+            Domain.cpu_relax ()
+          done;
+
+          let removed_by_d1 =
+            List.map
+              (fun (k, _v) ->
+                Domain.cpu_relax ();
+                remove k t)
+              to_add
+          in
+          let removed_by_d2 = Domain.join domain2 in
+
+          let rec test = function
+            (* not done with logical operator for readability *)
+            | [], [], [] -> true
+            | false :: xs, false :: xs', false :: xs''
+            | true :: xs, true :: xs', false :: xs''
+            | true :: xs, false :: xs', true :: xs'' ->
+                test (xs, xs', xs'')
+            | _, _, _ -> false
+          in
+
+          (* test properties : all elt have been added and can be sequentially found *)
+          test (added, removed_by_d1, removed_by_d2));
+      (* Parallel addition and removeal of elements in a sequentially build hash table. *)
+      Test.make ~count ~name:"par_add_remove" (pair nat_int_list nat_int_list)
+        (fun (lseq, lpar) ->
+          let to_add_seq, to_add_par = avoid_dup_keys lseq lpar in
+          let to_remove = List.rev lpar in
+          let open Htbl in
+          let t = init ~size_exponent:4 in
+          let sema = Semaphore.Binary.make false in
+
+          let added_seq = List.map (fun (k, v) -> add k v t) to_add_seq in
+
+          let domain2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.map
+                  (fun (k, _v) ->
+                    Domain.cpu_relax ();
+                    remove k t)
+                  to_remove)
+          in
+
+          (* make sure the other domain has begun *)
+          while not (Semaphore.Binary.try_acquire sema) do
+            Domain.cpu_relax ()
+          done;
+
+          let added_par =
+            List.map
+              (fun (k, v) ->
+                Domain.cpu_relax ();
+                add k v t)
+              to_add_par
+          in
+          let removed = Domain.join domain2 in
+
+          let rec test to_remove removed prev =
+            match (to_remove, removed) with
+            | [], [] -> true
+            | (k, _) :: to_remove, false :: removed ->
+                if List.mem k prev then test to_remove removed prev
+                else if List.mem_assoc k to_add_seq then false
+                else test to_remove removed prev
+            | (k, _) :: to_remove, true :: removed ->
+                if List.mem k prev then false
+                else test to_remove removed (k :: prev)
+            | _, _ -> false
+          in
+
+          (* to_add_seq and to_add_par have no identical key or
+             duplicated key. Addition should always succeed. *)
+          (* remove is done on key contained in*)
+          List.for_all (fun a -> a) added_seq
+          && List.for_all (fun a -> a) added_par
+          && test to_remove removed []);
+    ]
+
+let main () =
+  let to_alcotest = List.map QCheck_alcotest.to_alcotest in
+  Alcotest.run "Hshtbl"
+    [
+      ("one_domain", to_alcotest tests_one_domain);
+      ("two_domain", to_alcotest tests_two_domain);
+    ]
+;;
+
+main ()

--- a/test/hshtbl/qcheck_htbl.ml
+++ b/test/hshtbl/qcheck_htbl.ml
@@ -36,7 +36,7 @@ let tests_one_domain =
          insertion should success. *)
       Test.make ~count ~name:"seq_add" nat_int_list (fun l ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
           let l = List.sort_uniq (fun (a, _) (b, _) -> compare a b) l in
           List.for_all (fun (k, v) -> add k v t) l);
       (* Add a list of elements in a linked list and checks :
@@ -48,7 +48,7 @@ let tests_one_domain =
       *)
       Test.make ~count ~name:"seq_add_mem" nat_int_list (fun l ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
 
           let has_been_added = List.map (fun (k, v) -> add k v t) l in
 
@@ -72,7 +72,7 @@ let tests_one_domain =
       *)
       Test.make ~count ~name:"seq_remove" nat_int_list (fun l ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
 
           let has_been_added = List.map (fun (k, v) -> add k v t) l in
           let has_been_removed = List.map (fun (k, _) -> remove k t) l in
@@ -82,16 +82,16 @@ let tests_one_domain =
           && List.for_all (fun (k, _) -> not (mem k t)) l);
       (* Add a list of elements and then search random keys.
          This test checks that
-         forall k, l,  List.assoc_opt k l = Htbl.find k t
-         where t = List.iter (fun (k, v) -> Htbl.add k v t |> ignore) l (Htbl.init ~size_exponent:n)
+         forall k, l,  List.assoc_opt k l = Htbl.find_opt k t
+         where t = List.iter (fun (k, v) -> Htbl.add k v t |> ignore) l (Htbl.create ~size_exponent:n)
       *)
       Test.make ~count ~name:"seq_find" (pair nat_int_list nat_list)
         (fun (to_add, to_search_for) ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
 
           List.iter (fun (k, v) -> add k v t |> ignore) to_add;
-          let found = List.map (fun k -> find k t) to_search_for in
+          let found = List.map (fun k -> find_opt k t) to_search_for in
 
           (* Tested properties *)
           List.for_all2
@@ -101,10 +101,10 @@ let tests_one_domain =
       *)
       Test.make ~count ~name:"seq_find2" nat_int_list (fun l ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
 
           let has_been_added = List.map (fun (k, v) -> add k v t) l in
-          let should_be_found = List.map (fun (k, _) -> find k t) l in
+          let should_be_found = List.map (fun (k, _) -> find_opt k t) l in
           let res = List.combine has_been_added should_be_found in
 
           (* Tested properties *)
@@ -125,7 +125,7 @@ let tests_one_domain =
       *)
       Test.make ~count ~name:"seq_replace" nat_int_list (fun l ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
           let l = List.sort_uniq (fun (k, _) (k', _) -> compare k k') l in
 
           List.iter (fun (k, v) -> replace k v t) l;
@@ -134,7 +134,7 @@ let tests_one_domain =
           (* Tested properties *)
           List.for_all
             (fun (k, v) ->
-              match find k t with None -> false | Some v' -> v' = v + 1)
+              match find_opt k t with None -> false | Some v' -> v' = v + 1)
             l);
     ]
 
@@ -148,7 +148,7 @@ let tests_two_domain =
         (fun (l1, l2) ->
           let l1, l2 = avoid_dup_keys l1 l2 in
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
           let sema = Semaphore.Binary.make false in
 
           let domain2 =
@@ -178,12 +178,12 @@ let tests_two_domain =
              sequentially found *)
           List.for_all (fun a -> a) added_by_d1
           && List.for_all (fun a -> a) added_by_d2
-          && List.for_all (fun (k, v) -> find k t = Some v) l1
-          && List.for_all (fun (k, v) -> find k t = Some v) l2);
+          && List.for_all (fun (k, v) -> find_opt k t = Some v) l1
+          && List.for_all (fun (k, v) -> find_opt k t = Some v) l2);
       (* Parallel removal of elements in a sequentially built hash table. *)
       Test.make ~count ~name:"par_remove" nat_int_list (fun to_add ->
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
           let sema = Semaphore.Binary.make false in
           (* Sequential add *)
           let added = List.map (fun (k, v) -> add k v t) to_add in
@@ -228,7 +228,7 @@ let tests_two_domain =
           let to_add_seq, to_add_par = avoid_dup_keys lseq lpar in
           let to_remove = List.rev lpar in
           let open Htbl in
-          let t = init ~size_exponent:4 in
+          let t = create ~size_exponent:4 in
           let sema = Semaphore.Binary.make false in
 
           (* sequential adds *)

--- a/test/hshtbl/qcheck_llist.ml
+++ b/test/hshtbl/qcheck_llist.ml
@@ -21,7 +21,7 @@ let tests_one_domain =
          insertion should success. *)
       Test.make ~name:"seq_add" int_list (fun l ->
           let open Llist in
-          let t = init () in
+          let t = create () in
 
           let l = List.sort_uniq (fun a b -> -compare a b) l in
           List.for_all (fun elt -> add elt Dummy t) l);
@@ -34,7 +34,7 @@ let tests_one_domain =
       *)
       Test.make ~name:"seq_add2" int_list (fun l ->
           let open Llist in
-          let t = init () in
+          let t = create () in
 
           let has_been_added = List.map (fun elt -> add elt Dummy t) l in
 
@@ -60,7 +60,7 @@ let tests_two_domains =
       Test.make ~name:"add_add1" ~count:10000 (pair int_list int_list)
         (fun (l, l') ->
           let open Llist in
-          let t = init () in
+          let t = create () in
           let sema = Semaphore.Binary.make false in
 
           let l = List.sort_uniq compare l in
@@ -86,7 +86,7 @@ let tests_two_domains =
       Test.make ~name:"add_add" ~count:10000 (pair int_list int_list)
         (fun (l, l') ->
           let open Llist in
-          let t = init () in
+          let t = create () in
           let sema = Semaphore.Binary.make false in
 
           let d1 =
@@ -109,7 +109,7 @@ let tests_two_domains =
         (pair int_list (pair int_list int_list))
         (fun (l, (l', l'')) ->
           let open Llist in
-          let t = init () in
+          let t = create () in
           let sema = Semaphore.Binary.make false in
           List.iter (fun i -> ignore @@ add i Dummy t) (l @ l' @ l'');
 
@@ -132,7 +132,7 @@ let tests_two_domains =
           && List.for_all (fun elt -> mem elt t) (exclusion l'' (l @ l')));
       Test.make ~name:"add_remove" ~count:1000 small_nat (fun n ->
           let open Llist in
-          let t = init () in
+          let t = create () in
           let sema = Semaphore.Binary.make false in
 
           let l = List.init n (fun i -> i) in

--- a/test/hshtbl/qcheck_llist.ml
+++ b/test/hshtbl/qcheck_llist.ml
@@ -1,0 +1,170 @@
+module Llist = Lockfree__.Htbl.Llist
+
+module IntSet = Set.Make (struct
+  type t = int
+
+  let compare = compare
+end)
+
+let exclusion l l' =
+  let s = IntSet.of_list l in
+  let s' = IntSet.of_list l' in
+  IntSet.diff s (IntSet.inter s s') |> IntSet.elements
+
+(* making sur the generation int list are small enough (small_nat < 100) *)
+let int_list = QCheck.(list_of_size Gen.small_nat small_nat)
+
+let tests_one_domain =
+  QCheck.
+    [
+      (* Add a list of unique elements in a linked list. All
+         insertion should success. *)
+      Test.make ~name:"seq_add" int_list (fun l ->
+          let open Llist in
+          let t = init () in
+
+          let l = List.sort_uniq (fun a b -> -compare a b) l in
+          List.for_all (fun elt -> add elt Dummy t) l);
+      (* Add a list of elements in a linked list and checks :
+
+         - the elements that have already been added, the [add]
+         function returns [false] and [true] otherwise.
+
+         - [mem] on all added elements returns [true].
+      *)
+      Test.make ~name:"seq_add2" int_list (fun l ->
+          let open Llist in
+          let t = init () in
+
+          let has_been_added = List.map (fun elt -> add elt Dummy t) l in
+
+          let rec loop prev l has_been_added =
+            match (l, has_been_added) with
+            | [], [] -> true
+            | [], _ | _, [] -> false
+            | x :: xs, added :: has_been_added ->
+                if added = not (List.mem x prev) then
+                  loop (x :: prev) xs has_been_added
+                else false
+          in
+
+          loop [] l has_been_added
+          &&
+          let uniq = List.sort compare l in
+          List.for_all (fun elt -> mem elt t) uniq);
+    ]
+
+let tests_two_domains =
+  QCheck.
+    [
+      Test.make ~name:"add_add1" ~count:10000 (pair int_list int_list)
+        (fun (l, l') ->
+          let open Llist in
+          let t = init () in
+          let sema = Semaphore.Binary.make false in
+
+          let l = List.sort_uniq compare l in
+          let l' = List.sort_uniq compare l' in
+          let l' = List.filter (fun elt -> not (List.mem elt l)) l' in
+
+          let d1 =
+            Domain.spawn (fun () ->
+                while not (Semaphore.Binary.try_acquire sema) do
+                  Domain.cpu_relax ()
+                done;
+                List.map (fun i -> add i Dummy t) l)
+          in
+          let d2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.map (fun i -> add i Dummy t) l')
+          in
+          let res1 = Domain.join d1 in
+          let res2 = Domain.join d2 in
+
+          List.for_all (fun i -> i) res1 && List.for_all (fun i -> i) res2);
+      Test.make ~name:"add_add" ~count:10000 (pair int_list int_list)
+        (fun (l, l') ->
+          let open Llist in
+          let t = init () in
+          let sema = Semaphore.Binary.make false in
+
+          let d1 =
+            Domain.spawn (fun () ->
+                while not (Semaphore.Binary.try_acquire sema) do
+                  Domain.cpu_relax ()
+                done;
+                List.iter (fun i -> ignore @@ add i Dummy t) l)
+          in
+          let d2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.iter (fun i -> ignore @@ add i Dummy t) l')
+          in
+          let () = Domain.join d1 in
+          let () = Domain.join d2 in
+
+          List.for_all (fun elt -> mem elt t) (l @ l'));
+      Test.make ~name:"remove_remove"
+        (pair int_list (pair int_list int_list))
+        (fun (l, (l', l'')) ->
+          let open Llist in
+          let t = init () in
+          let sema = Semaphore.Binary.make false in
+          List.iter (fun i -> ignore @@ add i Dummy t) (l @ l' @ l'');
+
+          let d1 =
+            Domain.spawn (fun () ->
+                while not (Semaphore.Binary.try_acquire sema) do
+                  Domain.cpu_relax ()
+                done;
+                List.iter (fun i -> ignore @@ remove i t) l)
+          in
+          let d2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.iter (fun i -> ignore @@ remove i t) l')
+          in
+          let () = Domain.join d1 in
+          let () = Domain.join d2 in
+
+          List.for_all (fun elt -> not (mem elt t)) (l @ l')
+          && List.for_all (fun elt -> mem elt t) (exclusion l'' (l @ l')));
+      Test.make ~name:"add_remove" ~count:1000 small_nat (fun n ->
+          let open Llist in
+          let t = init () in
+          let sema = Semaphore.Binary.make false in
+
+          let l = List.init n (fun i -> i) in
+
+          let d1 =
+            Domain.spawn (fun () ->
+                while not (Semaphore.Binary.try_acquire sema) do
+                  Domain.cpu_relax ()
+                done;
+                List.map (fun i -> remove i t) l)
+          in
+          let d2 =
+            Domain.spawn (fun () ->
+                Semaphore.Binary.release sema;
+                List.map (fun i -> add i Dummy t) l)
+          in
+          let remove = Domain.join d1 in
+          let _add = Domain.join d2 in
+
+          List.for_all2
+            (fun has_been_removed k ->
+              if has_been_removed then not (mem k t) else mem k t)
+            remove l);
+    ]
+
+let main () =
+  let to_alcotest = List.map QCheck_alcotest.to_alcotest in
+  Alcotest.run "Llist"
+    [
+      ("one_domain", to_alcotest tests_one_domain);
+      ("two_domains", to_alcotest tests_two_domains);
+    ]
+;;
+
+main ()

--- a/test/hshtbl/stm_htbl.ml
+++ b/test/hshtbl/stm_htbl.ml
@@ -1,0 +1,73 @@
+open QCheck
+open STM
+module Htbl = Lockfree.Hshtbl
+
+module WSDConf = struct
+  type cmd = Add of int * int | Remove of int | Find of int | Mem of int
+
+  let show_cmd c =
+    match c with
+    | Add (k, v) -> "Add (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
+    | Remove k -> "Remove " ^ string_of_int k
+    | Find k -> "Find " ^ string_of_int k
+    | Mem k -> "Mem" ^ string_of_int k
+
+  module S = Map.Make (struct
+    type t = int
+
+    let compare = compare
+  end)
+
+  type state = int S.t
+  type sut = int Htbl.t
+
+  let arb_cmd _s =
+    let int_gen = Gen.nat in
+    QCheck.make ~print:show_cmd
+      (Gen.oneof
+         [
+           Gen.map2 (fun k v -> Add (k, v)) int_gen int_gen;
+           Gen.map (fun i -> Remove i) int_gen;
+           Gen.map (fun i -> Find i) int_gen;
+           Gen.map (fun i -> Mem i) int_gen;
+         ])
+
+  let init_state = S.empty
+  let init_sut () = Htbl.init ~size_exponent:12
+  let cleanup _ = ()
+
+  let next_state c s =
+    match c with
+    | Add (k, v) -> if S.mem k s then s else S.add k v s
+    | Find _ -> s
+    | Remove k -> if S.mem k s then S.remove k s else s
+    | Mem _k -> s
+
+  let precond _ _ = true
+
+  let run c t =
+    match c with
+    | Add (k, v) -> Res (bool, Htbl.add k v t)
+    | Remove k -> Res (bool, Htbl.remove k t)
+    | Find k -> Res (option int, Htbl.find k t)
+    | Mem k -> Res (bool, Htbl.mem k t)
+
+  let postcond c (s : state) res =
+    match (c, res) with
+    | Add (k, _), Res ((Bool, _), res) -> S.mem k s = not res
+    | Find k, Res ((Option Int, _), res) -> S.find_opt k s = res
+    | Remove k, Res ((Bool, _), res) -> S.mem k s = res
+    | Mem k, Res ((Bool, _), res) -> S.mem k s = res
+    | _, _ -> false
+end
+
+module WSDT_seq = STM_sequential.Make (WSDConf)
+module WSDT_dom = STM_domain.Make (WSDConf)
+
+let () =
+  let count = 200 in
+  QCheck_base_runner.run_tests_main
+    [
+      WSDT_seq.agree_test ~count ~name:"STM Lockfree.Htbl test sequential";
+      WSDT_dom.agree_test_par ~count ~name:"STM Lockfree.Htbl test parallel";
+    ]

--- a/test/hshtbl/stm_htbl.ml
+++ b/test/hshtbl/stm_htbl.ml
@@ -7,7 +7,7 @@ module WSDConf = struct
     | Add of int * int
     | Replace of int * int
     | Remove of int
-    | Find of int
+    | Find_opt of int
     | Mem of int
 
   let show_cmd c =
@@ -16,7 +16,7 @@ module WSDConf = struct
     | Replace (k, v) ->
         "Replace (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
     | Remove k -> "Remove " ^ string_of_int k
-    | Find k -> "Find " ^ string_of_int k
+    | Find_opt k -> "Find_opt " ^ string_of_int k
     | Mem k -> "Mem" ^ string_of_int k
 
   module S = Map.Make (struct
@@ -36,19 +36,19 @@ module WSDConf = struct
            Gen.map2 (fun k v -> Add (k, v)) int_gen int_gen;
            Gen.map2 (fun k v -> Replace (k, v)) int_gen int_gen;
            Gen.map (fun i -> Remove i) int_gen;
-           Gen.map (fun i -> Find i) int_gen;
+           Gen.map (fun i -> Find_opt i) int_gen;
            Gen.map (fun i -> Mem i) int_gen;
          ])
 
   let init_state = S.empty
-  let init_sut () = Htbl.init ~size_exponent:12
+  let init_sut () = Htbl.create ~size_exponent:12
   let cleanup _ = ()
 
   let next_state c s =
     match c with
     | Add (k, v) -> if S.mem k s then s else S.add k v s
     | Replace (k, v) -> S.add k v s
-    | Find _ -> s
+    | Find_opt _ -> s
     | Remove k -> if S.mem k s then S.remove k s else s
     | Mem _k -> s
 
@@ -59,14 +59,14 @@ module WSDConf = struct
     | Add (k, v) -> Res (bool, Htbl.add k v t)
     | Replace (k, v) -> Res (unit, Htbl.replace k v t)
     | Remove k -> Res (bool, Htbl.remove k t)
-    | Find k -> Res (option int, Htbl.find k t)
+    | Find_opt k -> Res (option int, Htbl.find_opt k t)
     | Mem k -> Res (bool, Htbl.mem k t)
 
   let postcond c (s : state) res =
     match (c, res) with
     | Add (k, _), Res ((Bool, _), res) -> S.mem k s = not res
     | Replace (_, _), Res ((Unit, _), ()) -> true
-    | Find k, Res ((Option Int, _), res) -> S.find_opt k s = res
+    | Find_opt k, Res ((Option Int, _), res) -> S.find_opt k s = res
     | Remove k, Res ((Bool, _), res) -> S.mem k s = res
     | Mem k, Res ((Bool, _), res) -> S.mem k s = res
     | _, _ -> false

--- a/test/hshtbl/stm_htbl_resizable.ml
+++ b/test/hshtbl/stm_htbl_resizable.ml
@@ -1,0 +1,85 @@
+open QCheck
+open STM
+module Htbl = Lockfree.Hshtbl_resizable
+
+module WSDConf = struct
+  type cmd =
+    | Add of int * int
+    | Remove of int
+    | Find of int
+    | Mem of int
+    | Is_empty
+
+  let show_cmd c =
+    match c with
+    | Add (k, v) -> "Add (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
+    | Remove k -> "Remove " ^ string_of_int k
+    | Find k -> "Find " ^ string_of_int k
+    | Mem k -> "Mem " ^ string_of_int k
+    | Is_empty -> "Is_empty"
+
+  module S = Map.Make (struct
+    type t = int
+
+    let compare = compare
+  end)
+
+  type state = int S.t
+  type sut = int Htbl.t
+
+  let arb_cmd _s =
+    let int_gen = Gen.nat in
+    QCheck.make ~print:show_cmd
+      (Gen.oneof
+         [
+           Gen.map2 (fun k v -> Add (k, v)) int_gen int_gen;
+           Gen.map (fun i -> Remove i) int_gen;
+           Gen.map (fun i -> Find i) int_gen;
+           Gen.map (fun i -> Mem i) int_gen;
+           Gen.return Is_empty;
+         ])
+
+  let init_state = S.empty
+  let init_sut () = Htbl.init ~size_exponent:12
+  let cleanup _ = ()
+
+  let next_state c s =
+    match c with
+    | Add (k, v) -> if S.mem k s then s else S.add k v s
+    | Find _ -> s
+    | Remove k -> if S.mem k s then S.remove k s else s
+    | Mem _k -> s
+    | Is_empty -> s
+
+  let precond _ _ = true
+
+  let run c t =
+    match c with
+    | Add (k, v) -> Res (bool, Htbl.add k v t)
+    | Remove k -> Res (bool, Htbl.remove k t)
+    | Find k -> Res (option int, Htbl.find k t)
+    | Mem k -> Res (bool, Htbl.mem k t)
+    | Is_empty -> Res (bool, Htbl.is_empty t)
+
+  let postcond c (s : state) res =
+    match (c, res) with
+    | Add (k, _), Res ((Bool, _), res) -> S.mem k s = not res
+    | Find k, Res ((Option Int, _), res) -> S.find_opt k s = res
+    | Remove k, Res ((Bool, _), res) -> S.mem k s = res
+    | Mem k, Res ((Bool, _), res) -> S.mem k s = res
+    | Is_empty, Res ((Bool, _), res) -> S.is_empty s = res
+    | _, _ -> false
+end
+
+module WSDT_seq = STM_sequential.Make (WSDConf)
+module WSDT_dom = STM_domain.Make (WSDConf)
+
+let () =
+  let count = 300 in
+  QCheck_base_runner.run_tests_main
+    [
+      WSDT_seq.agree_test ~count
+        ~name:"STM Lockfree.Htbl_resizable test sequential";
+      WSDT_dom.agree_test_par ~count
+        ~name:"STM Lockfree.Htbl_resizable test parallel";
+    ]

--- a/test/hshtbl/stm_htbl_resizable.ml
+++ b/test/hshtbl/stm_htbl_resizable.ml
@@ -5,6 +5,7 @@ module Htbl = Lockfree.Hshtbl_resizable
 module WSDConf = struct
   type cmd =
     | Add of int * int
+    | Replace of int * int
     | Remove of int
     | Find of int
     | Mem of int
@@ -13,6 +14,8 @@ module WSDConf = struct
   let show_cmd c =
     match c with
     | Add (k, v) -> "Add (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
+    | Replace (k, v) ->
+        "Replace (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
     | Remove k -> "Remove " ^ string_of_int k
     | Find k -> "Find " ^ string_of_int k
     | Mem k -> "Mem " ^ string_of_int k
@@ -33,6 +36,7 @@ module WSDConf = struct
       (Gen.oneof
          [
            Gen.map2 (fun k v -> Add (k, v)) int_gen int_gen;
+           Gen.map2 (fun k v -> Replace (k, v)) int_gen int_gen;
            Gen.map (fun i -> Remove i) int_gen;
            Gen.map (fun i -> Find i) int_gen;
            Gen.map (fun i -> Mem i) int_gen;
@@ -46,6 +50,7 @@ module WSDConf = struct
   let next_state c s =
     match c with
     | Add (k, v) -> if S.mem k s then s else S.add k v s
+    | Replace (k, v) -> S.add k v s
     | Find _ -> s
     | Remove k -> if S.mem k s then S.remove k s else s
     | Mem _k -> s
@@ -56,6 +61,7 @@ module WSDConf = struct
   let run c t =
     match c with
     | Add (k, v) -> Res (bool, Htbl.add k v t)
+    | Replace (k, v) -> Res (unit, Htbl.replace k v t)
     | Remove k -> Res (bool, Htbl.remove k t)
     | Find k -> Res (option int, Htbl.find k t)
     | Mem k -> Res (bool, Htbl.mem k t)
@@ -64,6 +70,7 @@ module WSDConf = struct
   let postcond c (s : state) res =
     match (c, res) with
     | Add (k, _), Res ((Bool, _), res) -> S.mem k s = not res
+    | Replace (_, _), Res ((Unit, _), ()) -> true
     | Find k, Res ((Option Int, _), res) -> S.find_opt k s = res
     | Remove k, Res ((Bool, _), res) -> S.mem k s = res
     | Mem k, Res ((Bool, _), res) -> S.mem k s = res

--- a/test/hshtbl/stm_htbl_resizable.ml
+++ b/test/hshtbl/stm_htbl_resizable.ml
@@ -7,7 +7,7 @@ module WSDConf = struct
     | Add of int * int
     | Replace of int * int
     | Remove of int
-    | Find of int
+    | Find_opt of int
     | Mem of int
     | Is_empty
 
@@ -17,7 +17,7 @@ module WSDConf = struct
     | Replace (k, v) ->
         "Replace (" ^ string_of_int k ^ ", " ^ string_of_int v ^ ")"
     | Remove k -> "Remove " ^ string_of_int k
-    | Find k -> "Find " ^ string_of_int k
+    | Find_opt k -> "Find_opt " ^ string_of_int k
     | Mem k -> "Mem " ^ string_of_int k
     | Is_empty -> "Is_empty"
 
@@ -38,20 +38,20 @@ module WSDConf = struct
            Gen.map2 (fun k v -> Add (k, v)) int_gen int_gen;
            Gen.map2 (fun k v -> Replace (k, v)) int_gen int_gen;
            Gen.map (fun i -> Remove i) int_gen;
-           Gen.map (fun i -> Find i) int_gen;
+           Gen.map (fun i -> Find_opt i) int_gen;
            Gen.map (fun i -> Mem i) int_gen;
            Gen.return Is_empty;
          ])
 
   let init_state = S.empty
-  let init_sut () = Htbl.init ~size_exponent:12
+  let init_sut () = Htbl.create ~size_exponent:12
   let cleanup _ = ()
 
   let next_state c s =
     match c with
     | Add (k, v) -> if S.mem k s then s else S.add k v s
     | Replace (k, v) -> S.add k v s
-    | Find _ -> s
+    | Find_opt _ -> s
     | Remove k -> if S.mem k s then S.remove k s else s
     | Mem _k -> s
     | Is_empty -> s
@@ -63,7 +63,7 @@ module WSDConf = struct
     | Add (k, v) -> Res (bool, Htbl.add k v t)
     | Replace (k, v) -> Res (unit, Htbl.replace k v t)
     | Remove k -> Res (bool, Htbl.remove k t)
-    | Find k -> Res (option int, Htbl.find k t)
+    | Find_opt k -> Res (option int, Htbl.find_opt k t)
     | Mem k -> Res (bool, Htbl.mem k t)
     | Is_empty -> Res (bool, Htbl.is_empty t)
 
@@ -71,7 +71,7 @@ module WSDConf = struct
     match (c, res) with
     | Add (k, _), Res ((Bool, _), res) -> S.mem k s = not res
     | Replace (_, _), Res ((Unit, _), ()) -> true
-    | Find k, Res ((Option Int, _), res) -> S.find_opt k s = res
+    | Find_opt k, Res ((Option Int, _), res) -> S.find_opt k s = res
     | Remove k, Res ((Bool, _), res) -> S.mem k s = res
     | Mem k, Res ((Bool, _), res) -> S.mem k s = res
     | Is_empty, Res ((Bool, _), res) -> S.is_empty s = res

--- a/test/hshtbl/stm_llist.ml
+++ b/test/hshtbl/stm_llist.ml
@@ -1,0 +1,70 @@
+open QCheck
+open STM
+module Llist = Lockfree__.Htbl.Llist
+
+module WSDConf = struct
+  type cmd = Add of int | Remove of int | Mem of int
+
+  let show_cmd c =
+    match c with
+    | Add k -> "Add " ^ string_of_int k
+    | Remove k -> "Remove " ^ string_of_int k
+    | Mem k -> "Mem " ^ string_of_int k
+
+  module S = Set.Make (struct
+    type t = int
+
+    let compare = compare
+  end)
+
+  type state = S.t
+  type sut = int Llist.t
+
+  let arb_cmd _s =
+    let int_gen = Gen.nat in
+    QCheck.make ~print:show_cmd
+      (Gen.oneof
+         [
+           Gen.map (fun k -> Add k) int_gen;
+           Gen.map (fun i -> Remove i) int_gen;
+           Gen.map (fun i -> Mem i) int_gen;
+         ])
+
+  let init_state = S.empty
+  let init_sut () = Llist.init ()
+  let cleanup _ = ()
+
+  let next_state c s =
+    match c with
+    | Add k -> if S.mem k s then s else S.add k s
+    | Mem _ -> s
+    | Remove k -> if S.mem k s then S.remove k s else s
+
+  let precond _ _ = true
+
+  let run c t =
+    match c with
+    | Add k -> Res (bool, Llist.add k Llist.Dummy t)
+    | Remove k -> Res (bool, Llist.remove k t)
+    | Mem k -> Res (bool, Llist.mem k t)
+
+  let postcond c (s : state) res =
+    match (c, res) with
+    | Add k, Res ((Bool, _), res) -> S.mem k s = not res
+    | Mem k, Res ((Bool, _), res) -> S.mem k s = res
+    | Remove k, Res ((Bool, _), res) -> S.mem k s = res
+    | _, _ -> false
+end
+
+module WSDT_seq = STM_sequential.Make (WSDConf)
+module WSDT_dom = STM_domain.Make (WSDConf)
+
+let () =
+  let count = 500 in
+  QCheck_base_runner.run_tests_main
+    [
+      WSDT_seq.agree_test ~count
+        ~name:"STM Lockfree.Linked_list test sequential";
+      WSDT_dom.agree_test_par ~count
+        ~name:"STM Lockfree.Linked_list test parallel";
+    ]

--- a/test/hshtbl/stm_llist.ml
+++ b/test/hshtbl/stm_llist.ml
@@ -8,12 +8,14 @@ module WSDConf = struct
     | Replace of int * int
     | Remove of int
     | Mem of int
+    | Find_opt of int
 
   let show_cmd c =
     match c with
     | Add (k, v) -> "Add (" ^ string_of_int k ^ "," ^ string_of_int v ^ ")"
     | Remove k -> "Remove " ^ string_of_int k
     | Mem k -> "Mem " ^ string_of_int k
+    | Find_opt k -> "Find_opt " ^ string_of_int k
     | Replace (k, v) ->
         "Replace (" ^ string_of_int k ^ "," ^ string_of_int v ^ ")"
 
@@ -35,10 +37,11 @@ module WSDConf = struct
            Gen.map2 (fun k v -> Replace (k, v)) int_gen int_gen;
            Gen.map (fun i -> Remove i) int_gen;
            Gen.map (fun i -> Mem i) int_gen;
+           Gen.map (fun i -> Find_opt i) int_gen;
          ])
 
   let init_state = S.empty
-  let init_sut () = Llist.init ()
+  let init_sut () = Llist.create ()
   let cleanup _ = ()
 
   let next_state c s =
@@ -46,6 +49,7 @@ module WSDConf = struct
     | Add (k, v) -> if S.mem k s then s else S.add k v s
     | Replace (k, v) -> S.add k v s
     | Mem _ -> s
+    | Find_opt _ -> s
     | Remove k -> if S.mem k s then S.remove k s else s
 
   let precond _ _ = true
@@ -56,6 +60,7 @@ module WSDConf = struct
     | Replace (k, v) -> Res (unit, Llist.replace k (Llist.Regular v) t |> ignore)
     | Remove k -> Res (bool, Llist.remove k t)
     | Mem k -> Res (bool, Llist.mem k t)
+    | Find_opt k -> Res (option int, Llist.find_opt k t)
 
   let postcond c (s : state) res =
     match (c, res) with
@@ -63,6 +68,7 @@ module WSDConf = struct
     | Replace (_k, _v), Res ((Unit, _), _) -> true
     | Mem k, Res ((Bool, _), res) -> S.mem k s = res
     | Remove k, Res ((Bool, _), res) -> S.mem k s = res
+    | Find_opt k, Res ((Option Int, _), res) -> S.find_opt k s = res
     | _, _ -> false
 end
 


### PR DESCRIPTION
### Last changes (16/05/23) : 
-  partially apply reviews (thanks @bartoszmodelski)
- add part of the documentation
- some renaming (still some more to do, as suggested in the review)
- wait-free `mem` and `find_opt`

### Still to do: 
- [ ] documentation
- [ ] add README note
- [ ] benchmarks
- [ ] finish cleaning the resizable htbl

In the implementation itself :
- [ ] add hash function
- [x] ~~wait-free mem function (may be keep both : a wait-free one and the current one that is helping with removal as they may be both useful)~~ : DONE 
- [x] ~~(optional) removal loop in the Llist.find function as written in the LockfreeList class in the AoMP book~~ : not improving performances.
 - [ ] (optional) changing the criteria to determine when to resize to reduce contention (currently every add and remove change a single value).

### For another PR 
Currently this hash table is actually extensible and not really resizable. It can only grow and has a maximum size. There are ideas on the book about how to make it resizable without limit (not sure about shrinking though).