### PR TITLE
A lock-free bounded queue

### DIFF
--- a/bench/bench_cue.ml
+++ b/bench/bench_cue.ml
@@ -1,0 +1,77 @@
+open Multicore_bench
+module Queue = Saturn_lockfree.Cue
+
+let run_one_domain ~budgetf ?(n_msgs = 50 * Util.iter_factor) () =
+  let t = Queue.create () in
+
+  let op push = if push then Queue.push t 101 else Queue.pop_opt t |> ignore in
+
+  let init _ =
+    assert (Queue.is_empty t);
+    Util.generate_push_and_pop_sequence n_msgs
+  in
+  let work _ bits = Util.Bits.iter op bits in
+
+  Times.record ~budgetf ~n_domains:1 ~init ~work ()
+  |> Times.to_thruput_metrics ~n:n_msgs ~singular:"message" ~config:"one domain"
+
+let run_one ~budgetf ?(n_adders = 2) ?(n_takers = 2)
+    ?(n_msgs = 50 * Util.iter_factor) () =
+  let n_domains = n_adders + n_takers in
+
+  let t = Queue.create () in
+
+  let n_msgs_to_take = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+  let n_msgs_to_add = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+
+  let init _ =
+    Atomic.set n_msgs_to_take n_msgs;
+    Atomic.set n_msgs_to_add n_msgs
+  in
+  let work i () =
+    if i < n_adders then
+      let rec work () =
+        let n = Util.alloc n_msgs_to_add in
+        if 0 < n then
+          let rec loop n =
+            if 0 < n then loop (n - Bool.to_int (Queue.try_push t i))
+            else work ()
+          in
+          loop n
+      in
+      work ()
+    else
+      let rec work () =
+        let n = Util.alloc n_msgs_to_take in
+        if n <> 0 then
+          let rec loop n =
+            if 0 < n then
+              match Queue.pop_opt t with
+              | None ->
+                  Domain.cpu_relax ();
+                  loop n
+              | Some _ -> loop (n - 1)
+            else work ()
+          in
+          loop n
+      in
+      work ()
+  in
+
+  let config =
+    let format role n =
+      Printf.sprintf "%d %s%s" n role (if n = 1 then "" else "s")
+    in
+    Printf.sprintf "%s, %s"
+      (format "nb adder" n_adders)
+      (format "nb taker" n_takers)
+  in
+
+  Times.record ~budgetf ~n_domains ~init ~work ()
+  |> Times.to_thruput_metrics ~n:n_msgs ~singular:"message" ~config
+
+let run_suite ~budgetf =
+  run_one_domain ~budgetf ()
+  @ (Util.cross [ 1; 2 ] [ 1; 2 ]
+    |> List.concat_map @@ fun (n_adders, n_takers) ->
+       run_one ~budgetf ~n_adders ~n_takers ())

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -1,6 +1,7 @@
 let benchmarks =
   [
     ("Saturn Relaxed_queue", Bench_relaxed_queue.run_suite);
+    ("Saturn_lockfree Cue", Bench_cue.run_suite);
     ("Saturn_lockfree Queue", Bench_queue.run_suite);
     ("Saturn_lockfree Single_prod_single_cons_queue", Bench_spsc_queue.run_suite);
     ("Saturn_lockfree Size", Bench_size.run_suite);

--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,7 @@
  (synopsis "Collection of lock-free data structures for Multicore OCaml")
  (depends
   (ocaml (>= 4.13))
+  (picos (>= 0.5.0))
   (domain_shims (and (>= 0.1.0) :with-test))
   (backoff (>= 0.1.0))
   (multicore-magic (>= 2.3.0))

--- a/saturn_lockfree.opam
+++ b/saturn_lockfree.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 depends: [
   "dune" {>= "3.14"}
   "ocaml" {>= "4.13"}
+  "picos" {>= "0.5.0"}
   "domain_shims" {>= "0.1.0" & with-test}
   "backoff" {>= "0.1.0"}
   "multicore-magic" {>= "2.3.0"}

--- a/src/saturn.ml
+++ b/src/saturn.ml
@@ -26,6 +26,7 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 ########
 *)
 
+module Cue = Saturn_lockfree.Cue
 module Queue = Saturn_lockfree.Queue
 module Queue_unsafe = Saturn_lockfree.Queue_unsafe
 module Stack = Saturn_lockfree.Stack

--- a/src/saturn.mli
+++ b/src/saturn.mli
@@ -30,6 +30,7 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 
 (** {1 Data structures} *)
 
+module Cue = Saturn_lockfree.Cue
 module Queue = Saturn_lockfree.Queue
 module Queue_unsafe = Saturn_lockfree.Queue_unsafe
 module Stack = Saturn_lockfree.Stack

--- a/src_lockfree/cue.ml
+++ b/src_lockfree/cue.ml
@@ -1,0 +1,260 @@
+(* Copyright (c) 2023-2024, Vesa Karvonen <vesa.a.j.k@gmail.com>
+
+   Permission to use, copy, modify, and/or distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+   REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+   AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+   INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+   LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+   OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+   PERFORMANCE OF THIS SOFTWARE. *)
+
+open Picos
+module Atomic = Multicore_magic.Transparent_atomic
+
+type ('a, _) node =
+  | Null : ('a, [> `Null ]) node
+  | Node : {
+      mutable _next : 'a link;
+      mutable value : 'a;
+      mutable capacity : int;
+      mutable counter : int;
+    }
+      -> ('a, [> `Node ]) node
+
+and 'a link = Link : ('a, [< `Null | `Node ]) node -> 'a link [@@unboxed]
+
+external link_as_node : 'a link -> ('a, [ `Node ]) node = "%identity"
+
+external next_as_atomic : ('a, [< `Node ]) node -> 'a link Atomic.t
+  = "%identity"
+
+let[@inline] get_capacity (Node r : (_, [< `Node ]) node) = r.capacity
+
+let[@inline] set_capacity (Node r : (_, [< `Node ]) node) value =
+  r.capacity <- value
+
+let[@inline] get_counter (Node r : (_, [< `Node ]) node) = r.counter
+
+let[@inline] set_counter (Node r : (_, [< `Node ]) node) value =
+  r.counter <- value
+
+let[@inline] get_next node = Atomic.get (next_as_atomic node)
+
+let[@inline] fenceless_get_next node =
+  Atomic.fenceless_get (next_as_atomic node)
+
+let[@inline] compare_and_set_next node before after =
+  Atomic.compare_and_set (next_as_atomic node) before after
+
+type 'a t = {
+  head : ('a, [ `Node ]) node Atomic.t;
+  head_waiters : Trigger.t list Atomic.t;
+  capacity : int;
+  tail_waiters : Trigger.t list Atomic.t;
+  tail : ('a, [ `Node ]) node Atomic.t;
+}
+
+let create ?(capacity = Int.max_int) () =
+  let value = Obj.magic () in
+  let node = Node { _next = Link Null; value; capacity; counter = 0 } in
+  let head = Atomic.make node |> Multicore_magic.copy_as_padded
+  and head_waiters = Atomic.make [] |> Multicore_magic.copy_as_padded
+  and tail_waiters = Atomic.make [] |> Multicore_magic.copy_as_padded
+  and tail = Atomic.make node |> Multicore_magic.copy_as_padded in
+  { head; head_waiters; capacity; tail_waiters; tail }
+  |> Multicore_magic.copy_as_padded
+
+let capacity_of t = t.capacity
+
+let is_empty t =
+  let head = Atomic.get t.head in
+  fenceless_get_next head == Link Null
+
+let rec snapshot t =
+  let head = Atomic.get t.head in
+  let tail = Atomic.fenceless_get t.tail in
+  match fenceless_get_next tail with
+  | Link (Node _ as node) ->
+      Atomic.compare_and_set t.tail tail node |> ignore;
+      snapshot t
+  | Link Null -> if Atomic.get t.head != head then snapshot t else (head, tail)
+
+let length t =
+  let head, tail = snapshot t in
+  get_counter tail - get_counter head
+
+(* *)
+
+let rec signal_all waiters =
+  let triggers = Atomic.fenceless_get waiters in
+  if triggers != [] then
+    if Atomic.compare_and_set waiters triggers [] then
+      List.iter Trigger.signal triggers
+    else signal_all waiters
+
+(* *)
+
+let rec peek t =
+  let old_head = Atomic.get t.head in
+  match fenceless_get_next old_head with
+  | Link Null ->
+      let trigger = Trigger.create () in
+      let triggers = Atomic.get t.tail_waiters in
+      if Atomic.compare_and_set t.tail_waiters triggers (trigger :: triggers)
+      then begin
+        if old_head != Atomic.get t.tail then signal_all t.tail_waiters
+        else
+          match Trigger.await trigger with
+          | None -> ()
+          | Some (exn, bt) ->
+              signal_all t.tail_waiters;
+              Printexc.raise_with_backtrace exn bt
+      end;
+      peek t
+  | Link (Node r) ->
+      let value = r.value in
+      if Atomic.get t.head != old_head then peek t else value
+
+(* *)
+
+let rec peek_opt t =
+  let head = Atomic.get t.head in
+  match fenceless_get_next head with
+  | Link Null -> None
+  | Link (Node r) ->
+      let value = r.value in
+      if Atomic.get t.head != head then peek_opt t else Some value
+
+(* *)
+
+let rec pop t backoff =
+  let old_head = Atomic.get t.head in
+  match fenceless_get_next old_head with
+  | Link Null ->
+      let trigger = Trigger.create () in
+      let triggers = Atomic.get t.tail_waiters in
+      if Atomic.compare_and_set t.tail_waiters triggers (trigger :: triggers)
+      then begin
+        if old_head != Atomic.get t.tail then signal_all t.tail_waiters
+        else
+          match Trigger.await trigger with
+          | None -> ()
+          | Some (exn, bt) ->
+              signal_all t.tail_waiters;
+              Printexc.raise_with_backtrace exn bt
+      end;
+      pop t backoff
+  | Link (Node node as new_head) ->
+      if Atomic.compare_and_set t.head old_head new_head then begin
+        let value = node.value in
+        node.value <- Obj.magic ();
+        signal_all t.head_waiters;
+        value
+      end
+      else pop t (Backoff.once backoff)
+
+(* *)
+
+let rec pop_opt t backoff =
+  let old_head = Atomic.get t.head in
+  match fenceless_get_next old_head with
+  | Link Null -> None
+  | Link (Node node as new_head) ->
+      if Atomic.compare_and_set t.head old_head new_head then begin
+        let value = node.value in
+        node.value <- Obj.magic ();
+        signal_all t.head_waiters;
+        Some value
+      end
+      else pop_opt t (Backoff.once backoff)
+
+(* *)
+
+let rec fix_tail tail new_tail =
+  let old_tail = Atomic.get tail in
+  if
+    get_next new_tail == Link Null
+    && not (Atomic.compare_and_set tail old_tail new_tail)
+  then fix_tail tail new_tail
+
+(* *)
+
+let rec push t new_node old_tail =
+  let capacity = get_capacity old_tail in
+  if capacity = 0 then begin
+    let old_head = Atomic.get t.head in
+    let length = get_counter old_tail - get_counter old_head in
+    let capacity = t.capacity - length in
+    if 0 < capacity then begin
+      set_capacity old_tail capacity;
+      push t new_node old_tail
+    end
+    else
+      let trigger = Trigger.create () in
+      let triggers = Atomic.get t.head_waiters in
+      if Atomic.compare_and_set t.head_waiters triggers (trigger :: triggers)
+      then begin
+        if old_head != Atomic.get t.head then signal_all t.head_waiters
+        else
+          match Trigger.await trigger with
+          | None -> ()
+          | Some (exn, bt) ->
+              signal_all t.head_waiters;
+              Printexc.raise_with_backtrace exn bt
+      end;
+      push t new_node old_tail
+  end
+  else begin
+    set_capacity new_node (capacity - 1);
+    set_counter new_node (get_counter old_tail + 1);
+    if not (compare_and_set_next old_tail (Link Null) (Link new_node)) then
+      push t new_node (link_as_node (get_next old_tail))
+    else begin
+      if not (Atomic.compare_and_set t.tail old_tail new_node) then
+        fix_tail t.tail new_node;
+      signal_all t.tail_waiters
+    end
+  end
+
+(* *)
+
+let rec try_push t new_node old_tail =
+  let capacity = get_capacity old_tail in
+  if capacity = 0 then
+    let old_head = Atomic.get t.head in
+    let length = get_counter old_tail - get_counter old_head in
+    let capacity = t.capacity - length in
+    0 < capacity
+    && begin
+         set_capacity old_tail capacity;
+         try_push t new_node old_tail
+       end
+  else begin
+    set_capacity new_node (capacity - 1);
+    set_counter new_node (get_counter old_tail + 1);
+    if not (compare_and_set_next old_tail (Link Null) (Link new_node)) then
+      try_push t new_node (link_as_node (get_next old_tail))
+    else begin
+      if not (Atomic.compare_and_set t.tail old_tail new_node) then
+        fix_tail t.tail new_node;
+      signal_all t.tail_waiters;
+      true
+    end
+  end
+
+(* *)
+
+let[@inline] pop t = pop t Backoff.default
+let[@inline] pop_opt t = pop_opt t Backoff.default
+
+let[@inline] push t value =
+  let new_node = Node { _next = Link Null; value; capacity = 0; counter = 0 } in
+  push t new_node (Atomic.get t.tail)
+
+let[@inline] try_push t value =
+  let new_node = Node { _next = Link Null; value; capacity = 0; counter = 0 } in
+  try_push t new_node (Atomic.get t.tail)

--- a/src_lockfree/cue.mli
+++ b/src_lockfree/cue.mli
@@ -1,0 +1,56 @@
+(* Copyright (c) 2023-2024, Vesa Karvonen <vesa.a.j.k@gmail.com>
+
+   Permission to use, copy, modify, and/or distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+   REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+   AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+   INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+   LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+   OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+   PERFORMANCE OF THIS SOFTWARE. *)
+
+(** Lock-free bounded queue. *)
+
+type !'a t
+(** *)
+
+val create : ?capacity:int -> unit -> 'a t
+(** *)
+
+val capacity_of : 'a t -> int
+(** *)
+
+val is_empty : 'a t -> bool
+(** *)
+
+val length : 'a t -> int
+(** *)
+
+val peek : 'a t -> 'a
+(** *)
+
+val peek_opt : 'a t -> 'a option
+(** *)
+
+val pop : 'a t -> 'a
+(** *)
+
+val pop_opt : 'a t -> 'a option
+(** *)
+
+val push : 'a t -> 'a -> unit
+(** *)
+
+val try_push : 'a t -> 'a -> bool
+(** *)
+
+(*
+val to_list : 'a t -> 'a list
+(** *)
+
+val transfer : 'a t -> 'a t
+(** *)
+*)

--- a/src_lockfree/dune
+++ b/src_lockfree/dune
@@ -13,7 +13,7 @@ let () =
 (library
  (name saturn_lockfree)
  (public_name saturn_lockfree)
- (libraries backoff multicore-magic |}
+ (libraries backoff multicore-magic picos |}
   ^ maybe_threads
   ^ {| ))
 

--- a/src_lockfree/saturn_lockfree.ml
+++ b/src_lockfree/saturn_lockfree.ml
@@ -26,6 +26,7 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 ########
 *)
 
+module Cue = Cue
 module Queue = Michael_scott_queue
 module Queue_unsafe = Michael_scott_queue_unsafe
 module Stack = Treiber_stack

--- a/src_lockfree/saturn_lockfree.mli
+++ b/src_lockfree/saturn_lockfree.mli
@@ -30,6 +30,7 @@ Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
 
 (** {1 Data structures} *)
 
+module Cue = Cue
 module Queue = Michael_scott_queue
 module Queue_unsafe = Michael_scott_queue_unsafe
 module Stack = Treiber_stack

--- a/test/cue/dune
+++ b/test/cue/dune
@@ -1,0 +1,7 @@
+(test
+ (package saturn_lockfree)
+ (name stm_cue)
+ (modules stm_cue)
+ (libraries saturn qcheck-core qcheck-stm.stm stm_run)
+ (action
+  (run %{test} --verbose)))

--- a/test/cue/stm_cue.ml
+++ b/test/cue/stm_cue.ml
@@ -1,0 +1,69 @@
+(** Sequential and Parallel model-based tests of (bounded queue) cue. *)
+
+open QCheck
+open STM
+module Cue = Saturn.Cue
+
+module Spec = struct
+  type cmd = Try_push of int | Pop_opt | Peek_opt | Length | Is_empty
+
+  let show_cmd c =
+    match c with
+    | Try_push i -> "Try_push " ^ string_of_int i
+    | Pop_opt -> "Pop_opt"
+    | Peek_opt -> "Peek_opt"
+    | Length -> "Length"
+    | Is_empty -> "Is_empty"
+
+  type state = int * int * int list
+  type sut = int Cue.t
+
+  let arb_cmd _s =
+    let int_gen = Gen.nat in
+    QCheck.make ~print:show_cmd
+      (Gen.oneof
+         [
+           Gen.map (fun i -> Try_push i) int_gen;
+           Gen.return Pop_opt;
+           Gen.return Peek_opt;
+           Gen.return Length;
+           Gen.return Is_empty;
+         ])
+
+  let init_state = (100, 0, [])
+  let init_sut () = Cue.create ~capacity:100 ()
+  let cleanup _ = ()
+
+  let next_state c ((capacity, size, content) as s) =
+    match c with
+    | Try_push i ->
+        if size = capacity then s else (capacity, size + 1, i :: content)
+    | Pop_opt -> (
+        match List.rev content with
+        | [] -> s
+        | _ :: content' -> (capacity, size - 1, List.rev content'))
+    | Peek_opt -> s
+    | Is_empty -> s
+    | Length -> s
+
+  let precond _ _ = true
+
+  let run c d =
+    match c with
+    | Try_push i -> Res (bool, Cue.try_push d i)
+    | Pop_opt -> Res (option int, Cue.pop_opt d)
+    | Peek_opt -> Res (option int, Cue.peek_opt d)
+    | Is_empty -> Res (bool, Cue.is_empty d)
+    | Length -> Res (int, Cue.length d)
+
+  let postcond c ((capacity, size, content) : state) res =
+    match (c, res) with
+    | Try_push _, Res ((Bool, _), res) -> res = (size < capacity)
+    | (Pop_opt | Peek_opt), Res ((Option Int, _), res) -> (
+        match List.rev content with [] -> res = None | j :: _ -> res = Some j)
+    | Is_empty, Res ((Bool, _), res) -> res = (content = [])
+    | Length, Res ((Int, _), res) -> res = size
+    | _, _ -> false
+end
+
+let () = Stm_run.run ~name:"Saturn_lockfree.Cue" (module Spec) |> exit


### PR DESCRIPTION
This implements a lock-free bounded queue &mdash; blocking using [domain-local-await](https://github.com/ocaml-multicore/domain-local-await/).

The data structure / algorithm is based on the Michael-Scott queue extended with length maintenance and caching of remaining capacity in such a way that additional contention is avoided in the happy paths.

TODO:
- [x] fix opam files to build on CI
- [x] use backoff from separate package
   - [x] fix dune-project
- [ ] `try_push`, `length` (can be done in `O(1)`), `is_empty`
- [ ] tests
- [ ] ability to change capacity
- [ ] benchmarking
- [ ] consider whether making wakeups fair is worth it (currently all awaiters are woken up so there is no fairness)
- [ ] documentation