### PR TITLE
Add a barrier module in `tests` to replace the use of `Semaphore`.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -25,7 +25,8 @@ runs with parallelism:
 
 - make a domain repeat its operations. In particular, that usually works well
   when testing a single function.
-- use a semaphore to make all domains wait for each other before starting (see
+- use the provided [barrier](barrier/barrier.mli) module to make all domains
+  wait for each other before starting (see
   [these tests for example) ](ws_deque/qcheck_ws_deque.ml)).
 - if you are still not sure your tests have a good chance to run in parallel,
   try it in the top level, and use print or outputs to understand what is

--- a/test/barrier/barrier.ml
+++ b/test/barrier/barrier.ml
@@ -13,7 +13,8 @@ let await { waiters; size; passed } =
   while Atomic.get waiters < size do
     Domain.cpu_relax ()
   done;
-  (* Have passed. Increased [passed]. If last one to pass, reset the barrier.  *)
+  (* Have passed. Increased [passed]. If last one to pass, reset the
+     barrier. *)
   if Atomic.fetch_and_add passed 1 = size - 1 then (
     Atomic.set passed 0;
     Atomic.set waiters 0)

--- a/test/barrier/barrier.ml
+++ b/test/barrier/barrier.ml
@@ -1,20 +1,17 @@
 type t = { waiters : int Atomic.t; size : int; passed : int Atomic.t }
 
-let create n = { waiters = Atomic.make 0; size = n; passed = Atomic.make 0 }
+let create n = { waiters = Atomic.make n; size = n; passed = Atomic.make 0 }
 
 let await { waiters; size; passed } =
-  (* Wait for the barrier to release the previous group *)
+  if Atomic.fetch_and_add passed 1 = size - 1 then (
+    Atomic.set passed 0;
+    Atomic.set waiters 0);
+
   while Atomic.get waiters = size do
     Domain.cpu_relax ()
   done;
-  (* Add itself in the waiters group *)
+
   Atomic.incr waiters;
-  (* Wait for enough waiters to arrive *)
   while Atomic.get waiters < size do
     Domain.cpu_relax ()
-  done;
-  (* Have passed. Increased [passed]. If last one to pass, reset the
-     barrier. *)
-  if Atomic.fetch_and_add passed 1 = size - 1 then (
-    Atomic.set passed 0;
-    Atomic.set waiters 0)
+  done

--- a/test/barrier/barrier.ml
+++ b/test/barrier/barrier.ml
@@ -1,0 +1,19 @@
+type t = { waiters : int Atomic.t; size : int; passed : int Atomic.t }
+
+let create n = { waiters = Atomic.make 0; size = n; passed = Atomic.make 0 }
+
+let await { waiters; size; passed } =
+  (* Wait for the barrier to release the previous group *)
+  while Atomic.get waiters = size do
+    Domain.cpu_relax ()
+  done;
+  (* Add itself in the waiters group *)
+  Atomic.incr waiters;
+  (* Wait for enough waiters to arrive *)
+  while Atomic.get waiters < size do
+    Domain.cpu_relax ()
+  done;
+  (* Have passed. Increased [passed]. If last one to pass, reset the barrier.  *)
+  if Atomic.fetch_and_add passed 1 = size - 1 then (
+    Atomic.set passed 0;
+    Atomic.set waiters 0)

--- a/test/barrier/barrier.mli
+++ b/test/barrier/barrier.mli
@@ -1,11 +1,10 @@
 (** A barrier is a synchronisation tool.
 
-    A barrier of capacity [n] blocks domains until [n] of them are
-    waiting. Then these [n] domains can pass. Then the barrier is
-    reset.
+    A barrier of capacity [n] blocks domains until [n] of them are waiting. Then
+    these [n] domains can pass. Then the barrier is reset.
 
-    Note that this barrier is not starvation-free if there is more
-    domains trying to pass it than its capacity.
+    Note that this barrier is not starvation-free if there is more domains
+    trying to pass it than its capacity.
 
     This module has been written to help make sure that in `qcheck` tests and
     unitary tests, multiple domains are actually running in parallel.
@@ -21,9 +20,8 @@
        List.iter Domain.join domains
     ]}
 
-    you are most likely going to get the number in order (or almost),
-    because printing a line is way much cheaper than spawning a
-    domain.
+    you are most likely going to get the number in order (or almost), because
+    printing a line is way much cheaper than spawning a domain.
 
     Whereas with the barrier, you should get a random order :
     {[
@@ -47,6 +45,6 @@ val create : int -> t
 (** [create c] returns a barrier of capacity [c]. *)
 
 val await : t -> unit
-(** A domain calling [await barrier] will only be able to
-    progress past this function once the number of domains waiting at
-    the barrier is egal to its capacity . *)
+(** A domain calling [await barrier] will only be able to progress past this
+    function once the number of domains waiting at the barrier is egal to its
+    capacity . *)

--- a/test/barrier/barrier.mli
+++ b/test/barrier/barrier.mli
@@ -1,0 +1,52 @@
+(** A barrier is a synchronisation tool.
+
+    A barrier of capacity [n] blocks domains until [n] of them are
+    waiting. Then these [n] domains can pass. Then the barrier is
+    reset.
+
+    Note that this barrier is not starvation-free if there is more
+    domains trying to pass it than its capacity.
+
+    This module has been written to help make sure that in `qcheck` tests and
+    unitary tests, multiple domains are actually running in parallel.
+
+
+    If you try this :
+    {[
+    let example nb_domain =
+       let printer i () =
+         Format.printf "Domain spawn in %dth position@." i
+       in
+       let domains = List.init nb_domain (fun i -> Domain.spawn (printer i)) in
+       List.iter Domain.join domains
+    ]}
+
+    you are most likely going to get the number in order (or almost),
+    because printing a line is way much cheaper than spawning a
+    domain.
+
+    Whereas with the barrier, you should get a random order :
+    {[
+    let example_with_barrier nb_domain =
+       let barrier = Barrier.create nb_domain in
+
+       let printer i () =
+         Barrier.await barrier;
+         Format.printf "Domain spawn in %dth position@." i
+       in
+
+       let domains = List.init nb_domain (fun i -> Domain.spawn (printer i)) in
+
+       List.iter Domain.join domains
+    ]}
+*)
+
+type t
+
+val create : int -> t
+(** [create c] returns a barrier of capacity [c]. *)
+
+val await : t -> unit
+(** A domain calling [await barrier] will only be able to
+    progress past this function once the number of domains waiting at
+    the barrier is egal to its capacity . *)

--- a/test/barrier/barrier.mli
+++ b/test/barrier/barrier.mli
@@ -37,6 +37,19 @@
 
        List.iter Domain.join domains
     ]}
+
+   It also enables to have rounds such as a domain can not begin a new
+   round before all other domains have finished the previous one. This
+   can be easily observed by changing the printer function in the
+   previous example by this one :
+
+    {[
+    let printer i () =
+      Barrier.await barrier;
+      Format.printf "First round - Domain spawn in %dth position@." i;
+      Barrier.await barrier;
+      Format.printf "Second round - Domain spawn in %dth position@." i
+    ]}
 *)
 
 type t

--- a/test/barrier/dune
+++ b/test/barrier/dune
@@ -1,0 +1,2 @@
+(library
+ (name barrier))

--- a/test/michael_scott_queue/dune
+++ b/test/michael_scott_queue/dune
@@ -11,7 +11,7 @@
 
 (test
  (name qcheck_michael_scott_queue)
- (libraries saturn qcheck qcheck-alcotest)
+ (libraries saturn barrier qcheck qcheck-alcotest)
  (modules qcheck_michael_scott_queue))
 
 (test

--- a/test/michael_scott_queue/qcheck_michael_scott_queue.ml
+++ b/test/michael_scott_queue/qcheck_michael_scott_queue.ml
@@ -85,7 +85,7 @@ let tests_two_domains =
         (pair small_nat small_nat) (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
-          let sema = Semaphore.Binary.make false in
+          let barrier = Barrier.create 2 in
 
           (* Using these lists instead of a random one enables to
              check for more properties. *)
@@ -103,13 +103,11 @@ let tests_two_domains =
 
           let domain1 =
             Domain.spawn (fun () ->
-                Semaphore.Binary.release sema;
+                Barrier.await barrier;
                 work lpush1)
           in
           let popped2 =
-            while not (Semaphore.Binary.try_acquire sema) do
-              Domain.cpu_relax ()
-            done;
+            Barrier.await barrier;
             work lpush2
           in
 
@@ -145,7 +143,7 @@ let tests_two_domains =
         (pair small_nat small_nat) (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
-          let sema = Semaphore.Binary.make false in
+          let barrier = Barrier.create 2 in
 
           let lpush1 = List.init npush1 (fun i -> i) in
           let lpush2 = List.init npush2 (fun i -> i + npush1) in
@@ -173,13 +171,11 @@ let tests_two_domains =
 
           let domain1 =
             Domain.spawn (fun () ->
-                Semaphore.Binary.release sema;
+                Barrier.await barrier;
                 work lpush1)
           in
           let popped2 =
-            while not (Semaphore.Binary.try_acquire sema) do
-              Domain.cpu_relax ()
-            done;
+            Barrier.await barrier;
             work lpush2
           in
 

--- a/test/mpsc_queue/dune
+++ b/test/mpsc_queue/dune
@@ -8,7 +8,7 @@
 
 (test
  (name qcheck_mpsc_queue)
- (libraries saturn qcheck qcheck-alcotest)
+ (libraries saturn barrier qcheck qcheck-alcotest)
  (modules qcheck_mpsc_queue))
 
 (test

--- a/test/spsc_queue/dune
+++ b/test/spsc_queue/dune
@@ -13,7 +13,7 @@
 
 (test
  (name qcheck_spsc_queue)
- (libraries saturn qcheck "qcheck-alcotest")
+ (libraries saturn barrier qcheck "qcheck-alcotest")
  (modules qcheck_spsc_queue))
 
 (test

--- a/test/treiber_stack/dune
+++ b/test/treiber_stack/dune
@@ -11,7 +11,7 @@
 
 (test
  (name qcheck_treiber_stack)
- (libraries saturn qcheck qcheck-alcotest)
+ (libraries saturn barrier qcheck qcheck-alcotest)
  (modules qcheck_treiber_stack))
 
 (test

--- a/test/ws_deque/dune
+++ b/test/ws_deque/dune
@@ -16,7 +16,7 @@
 
 (test
  (name qcheck_ws_deque)
- (libraries saturn qcheck "qcheck-alcotest")
+ (libraries barrier saturn qcheck "qcheck-alcotest")
  (modules qcheck_ws_deque))
 
 (test


### PR DESCRIPTION
This PR provides a very basic `barrier` implementation to replace the use of semaphores in `qcheck` tests. `Semaphores` (and now `barriers`) are used to improve chances that domains run in parallel even if the work they are doing is very small and fast. 

The `barrier`  module makes this task easier as there is no need to use different modules for 2 domains or more, like previously with `Semaphore.Binary` and `Semaphore.Counting` or some weird use or `Semaphore.Counting` (that were just meant to emulate a barrier).

```ocaml
let sema = Semaphore.Binary.create () in
let domain1 =
     Domain.spawn (fun () ->
            Semaphore.Binary.release sema;
            work ())  in
let popped2 =
      while not (Semaphore.Binary.try_acquire sema) do
            Domain.cpu_relax ()
      done;
      work ()) in
  ....
````

becomes :
```ocaml
let barrier = Barrier.create 2 in
let domain1 =
     Domain.spawn (fun () ->
            Barrier.await barrier;
            work ())  in
let popped2 =
     Barrier.await barrier;
     work () in
  ....
```