### PR TITLE
`pop_opt`, `peek`, `peek_opt`  functions for `queue`

### DIFF
--- a/bench/bench_spsc_queue.ml
+++ b/bench/bench_spsc_queue.ml
@@ -16,7 +16,7 @@ let run () =
         start_time)
   in
   for _ = 1 to item_count do
-    while Option.is_none (Spsc_queue.pop queue) do
+    while Option.is_none (Spsc_queue.pop_opt queue) do
       ()
     done
   done;

--- a/src_lockfree/michael_scott_queue.mli
+++ b/src_lockfree/michael_scott_queue.mli
@@ -37,14 +37,26 @@ val is_empty : 'a t -> bool
 val push : 'a t -> 'a -> unit
 (** [push q v] adds the element [v] at the end of the queue [q]. *)
 
-val pop : 'a t -> 'a option
+exception Empty
+(** Raised when {!pop} or {!peek} is applied to an empty queue. *)
+
+val pop : 'a t -> 'a
+(** [pop q] removes and returns the first element in queue [q].
+
+    @raise Empty if [q] is empty. *)
+
+val pop_opt : 'a t -> 'a option
 (** [pop q] removes and returns the first element in queue [q], or
     returns [None] if the queue is empty. *)
 
-val clean_until : 'a t -> ('a -> bool) -> unit
-(** [clean_until q f] drops the prefix of the queue until the element [e],
-    where [f e] is [true]. If no such element exists, then the queue is
-    emptied. *)
+val peek : 'a t -> 'a
+(** [peek q] returns the first element in queue [q].
+
+    @raise Empty if [q] is empty. *)
+
+val peek_opt : 'a t -> 'a option
+(** [peek q] returns the first element in queue [q], or
+    returns [None] if the queue is empty. *)
 
 type 'a cursor
 (** The type of cursor. *)

--- a/src_lockfree/michael_scott_queue.mli
+++ b/src_lockfree/michael_scott_queue.mli
@@ -46,7 +46,7 @@ val pop : 'a t -> 'a
     @raise Empty if [q] is empty. *)
 
 val pop_opt : 'a t -> 'a option
-(** [pop q] removes and returns the first element in queue [q], or
+(** [pop_opt q] removes and returns the first element in queue [q], or
     returns [None] if the queue is empty. *)
 
 val peek : 'a t -> 'a
@@ -55,7 +55,7 @@ val peek : 'a t -> 'a
     @raise Empty if [q] is empty. *)
 
 val peek_opt : 'a t -> 'a option
-(** [peek q] returns the first element in queue [q], or
+(** [peek_opt q] returns the first element in queue [q], or
     returns [None] if the queue is empty. *)
 
 type 'a cursor

--- a/src_lockfree/mpsc_queue.mli
+++ b/src_lockfree/mpsc_queue.mli
@@ -12,26 +12,6 @@ exception Closed
 val create : unit -> 'a t
 (** [create ()] returns a new empty queue. *)
 
-val push : 'a t -> 'a -> unit
-(** [push q v] adds the element [v] at the end of the queue [q].  This
-    can be used safely by multiple producer domains, in parallel with
-    the other operations.
-
-    @raise Closed if [q] is closed. *)
-
-val pop : 'a t -> 'a option
-(** [pop q] removes and returns the first element in queue [q] or
-    returns [None] if the queue is empty.
-
-    @raise Closed if [q] is closed and empty. *)
-
-val push_head : 'a t -> 'a -> unit
-(** [push_head q v] adds the element [v] at the head of the queue
-    [q]. This can only be used by the consumer (if run in parallel
-    with {!pop}, the item might be skipped).
-
-    @raise Closed if [q] is closed and empty. *)
-
 val is_empty : 'a t -> bool
 (** [is_empty q] is [true] if calling [pop] would return [None].
 
@@ -42,3 +22,48 @@ val close : 'a t -> unit
     being pushed by the producers (i.e. with {!push}).
 
     @raise Closed if [q] has already been closed. *)
+
+val push : 'a t -> 'a -> unit
+(** [push q v] adds the element [v] at the end of the queue [q]. This
+    can be used safely by multiple producer domains, in parallel with
+    the other operations.
+
+    @raise Closed if [q] is closed. *)
+
+(** {2 Consumer-only functions} *)
+
+exception Empty
+(** Raised when {!pop} or {!peek} is applied to an empty queue. *)
+
+val pop : 'a t -> 'a
+(** [pop q] removes and returns the first element in queue [q].
+
+    @raise Empty if [q] is empty.
+
+    @raise Closed if [q] is closed and empty. *)
+
+val pop_opt : 'a t -> 'a option
+(** [pop_opt q] removes and returns the first element in queue [q] or
+    returns [None] if the queue is empty.
+
+    @raise Closed if [q] is closed and empty. *)
+
+val peek : 'a t -> 'a
+(** [peek q] returns the first element in queue [q].
+
+    @raise Empty if [q] is empty.
+
+    @raise Closed if [q] is closed and empty. *)
+
+val peek_opt : 'a t -> 'a option
+(** [peek_opt q] returns the first element in queue [q] or
+    returns [None] if the queue is empty.
+
+    @raise Closed if [q] is closed and empty. *)
+
+val push_head : 'a t -> 'a -> unit
+(** [push_head q v] adds the element [v] at the head of the queue
+    [q]. This can only be used by the consumer (if run in parallel
+    with {!pop}, the item might be skipped).
+
+    @raise Closed if [q] is closed and empty. *)

--- a/src_lockfree/spsc_queue.mli
+++ b/src_lockfree/spsc_queue.mli
@@ -4,26 +4,59 @@ type 'a t
 (** Type of single-producer single-consumer non-resizable domain-safe
    queue that works in FIFO order. *)
 
-exception Full
-(** Raised when {!push} is applied to a full queue. *)
-
 val create : size_exponent:int -> 'a t
 (** [create ~size_exponent:int] returns a new queue of maximum size
    [2^size_exponent] and initially empty. *)
-
-val push : 'a t -> 'a -> unit
-(** [push q v] adds the element [v] at the end of the queue [q]. This
-    method can be used by at most one domain at the time.
-
-   @raise [Full] if the queue is full.
-*)
-
-val pop : 'a t -> 'a option
-(** [pop q] removes and returns the first element in queue [q], or
-    returns [None] if the queue is empty. This method can be used by
-    at most one domain at the time. *)
 
 val size : 'a t -> int
 (** [size] returns the size of the queue. This method linearizes only when called
   from either consumer or producer domain. Otherwise, it is safe to call but
   provides only an *indication* of the size of the structure. *)
+
+(** {1 Producer functions} *)
+
+exception Full
+(** Raised when {!push} is applied to a full queue. *)
+
+val push : 'a t -> 'a -> unit
+(** [push q v] adds the element [v] at the end of the queue [q]. This
+    method can be used by at most one domain at the time.
+
+   @raise Full if the queue is full.
+*)
+
+val try_push : 'a t -> 'a -> bool
+(** [try_push q v] tries to add the element [v] at the end of the
+    queue [q]. It fails it the queue [q] is full.  This method can be
+    used by at most one domain at the time.
+*)
+
+(** {2 Consumer functions} *)
+
+exception Empty
+(** Raised when {!pop} or {!peek} is applied to an empty queue. *)
+
+val pop : 'a t -> 'a
+(** [pop q] removes and returns the first element in queue [q]. This
+    method can be used by at most one domain at the time.
+
+    @raise Empty if [q] is empty.
+*)
+
+val pop_opt : 'a t -> 'a option
+(** [pop_opt q] removes and returns the first element in queue [q], or
+    returns [None] if the queue is empty. This method can be used by
+    at most one domain at the time. *)
+
+val peek : 'a t -> 'a
+(** [peek q] returns the first element in queue [q]. This method can be
+    used by at most one domain at the time.
+
+    @raise Empty if [q] is empty.
+*)
+
+val peek_opt : 'a t -> 'a option
+(** [peek_opt q] returns the first element in queue [q], or [None]
+    if the queue is empty. This method can be used by at most one
+    domain at the time.
+*)

--- a/src_lockfree/treiber_stack.mli
+++ b/src_lockfree/treiber_stack.mli
@@ -15,6 +15,17 @@ val is_empty : 'a t -> bool
 val push : 'a t -> 'a -> unit
 (** [push s v] adds the element [v] at the top of stack [s]. *)
 
-val pop : 'a t -> 'a option
-(** [pop a] removes and returns the topmost element in the
-    stack [s], or returns [None] if the stack is empty. *)
+exception Empty
+(** Raised when {!pop} or {!peek} is applied to an empty queue. *)
+
+val pop : 'a t -> 'a
+(** [pop s] removes and returns the topmost element in the
+    stack [s].
+
+    @raise Empty if [a] is empty.
+*)
+
+val pop_opt : 'a t -> 'a option
+(** [pop_opt s] removes and returns the topmost element in the
+    stack [s], or returns [None] if the stack is empty.
+*)

--- a/src_lockfree/ws_deque.ml
+++ b/src_lockfree/ws_deque.ml
@@ -33,7 +33,9 @@ module type S = sig
   val create : unit -> 'a t
   val push : 'a t -> 'a -> unit
   val pop : 'a t -> 'a
+  val pop_opt : 'a t -> 'a option
   val steal : 'a t -> 'a
+  val steal_opt : 'a t -> 'a option
 end
 
 module CArray = struct
@@ -169,6 +171,8 @@ module M : S = struct
             set_next_shrink q);
           release out)
 
+  let pop_opt q = try Some (pop q) with Exit -> None
+
   let rec steal q =
     let t = Atomic.get q.top in
     let b = Atomic.get q.bottom in
@@ -181,4 +185,6 @@ module M : S = struct
       else (
         Domain.cpu_relax ();
         steal q)
+
+  let steal_opt q = try Some (steal q) with Exit -> None
 end

--- a/src_lockfree/ws_deque.mli
+++ b/src_lockfree/ws_deque.mli
@@ -34,6 +34,10 @@ module type S = sig
       @raise [Exit] if the queue is empty.
       *)
 
+  val pop_opt : 'a t -> 'a option
+  (** [pop_opt q] removes and returns the first element in queue [q], or
+    returns [None] if the queue is empty.  *)
+
   (** {1 Stealers function} *)
 
   val steal : 'a t -> 'a
@@ -42,7 +46,12 @@ module type S = sig
       queue [q].
 
       @raise [Exit] if the queue is empty.
-      *)
+  *)
+
+  val steal_opt : 'a t -> 'a option
+  (** [steal_opt q] removes and returns the last element from queue
+      [q], or returns [None] if the queue is empty. It should only be
+      invoked by domain which doesn't own the queue [q]. *)
 end
 
 module M : S

--- a/test/michael_scott_queue/michael_scott_queue_dscheck.ml
+++ b/test/michael_scott_queue/michael_scott_queue_dscheck.ml
@@ -113,7 +113,8 @@ let two_domains () =
                 (fun elt ->
                   (* even nums belong to thr 1, odd nums to thr 2 *)
                   Michael_scott_queue.push stack elt;
-                  lpop := Option.get (Michael_scott_queue.pop_opt stack) :: !lpop)
+                  lpop :=
+                    Option.get (Michael_scott_queue.pop_opt stack) :: !lpop)
                 lpush)
           |> ignore)
         lists;

--- a/test/michael_scott_queue/michael_scott_queue_dscheck.ml
+++ b/test/michael_scott_queue/michael_scott_queue_dscheck.ml
@@ -2,7 +2,7 @@ let drain queue =
   let remaining = ref 0 in
   while not (Michael_scott_queue.is_empty queue) do
     remaining := !remaining + 1;
-    assert (Option.is_some (Michael_scott_queue.pop queue))
+    assert (Option.is_some (Michael_scott_queue.pop_opt queue))
   done;
   !remaining
 
@@ -21,7 +21,7 @@ let producer_consumer () =
       let popped = ref 0 in
       Atomic.spawn (fun () ->
           for _ = 1 to items_total do
-            match Michael_scott_queue.pop queue with
+            match Michael_scott_queue.pop_opt queue with
             | None -> ()
             | Some v ->
                 assert (v == !popped + 1);
@@ -33,6 +33,47 @@ let producer_consumer () =
           Atomic.check (fun () ->
               let remaining = drain queue in
               !popped + remaining = items_total)))
+
+let producer_consumer_peek () =
+  Atomic.trace (fun () ->
+      let queue = Michael_scott_queue.create () in
+      let items_total = 1 in
+      let pushed = List.init items_total (fun i -> i) in
+
+      (* producer *)
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Michael_scott_queue.push queue elt) pushed);
+
+      (* consumer *)
+      let popped = ref [] in
+      let peeked = ref [] in
+      Atomic.spawn (fun () ->
+          for _ = 1 to items_total do
+            peeked := Michael_scott_queue.peek_opt queue :: !peeked;
+            popped := Michael_scott_queue.pop_opt queue :: !popped
+          done);
+
+      (* checks*)
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              let rec check pushed peeked popped =
+                match (pushed, peeked, popped) with
+                | _, [], [] -> true
+                | _, None :: peeked, None :: popped ->
+                    check pushed peeked popped
+                | push :: pushed, None :: peeked, Some pop :: popped
+                  when push = pop ->
+                    check pushed peeked popped
+                | push :: pushed, Some peek :: peeked, Some pop :: popped
+                  when push = peek && push = pop ->
+                    check pushed peeked popped
+                | _, _, _ -> false
+              in
+              check pushed (List.rev !peeked) (List.rev !popped));
+          Atomic.check (fun () ->
+              let remaining = drain queue in
+              let popped = List.filter Option.is_some !popped in
+              List.length popped + remaining = items_total)))
 
 let two_producers () =
   Atomic.trace (fun () ->
@@ -72,7 +113,7 @@ let two_domains () =
                 (fun elt ->
                   (* even nums belong to thr 1, odd nums to thr 2 *)
                   Michael_scott_queue.push stack elt;
-                  lpop := Option.get (Michael_scott_queue.pop stack) :: !lpop)
+                  lpop := Option.get (Michael_scott_queue.pop_opt stack) :: !lpop)
                 lpush)
           |> ignore)
         lists;
@@ -102,6 +143,7 @@ let () =
       ( "basic",
         [
           test_case "1-producer-1-consumer" `Slow producer_consumer;
+          test_case "1-producer-1-consumer-peek" `Slow producer_consumer_peek;
           test_case "2-producers" `Slow two_producers;
           test_case "2-domains" `Slow two_domains;
         ] );

--- a/test/michael_scott_queue/qcheck_michael_scott_queue.ml
+++ b/test/michael_scott_queue/qcheck_michael_scott_queue.ml
@@ -144,8 +144,8 @@ let tests_two_domains =
       (* TEST 1 - two domains doing multiple times one push then one pop_opt.
          Parallel [push] and [pop_opt].
       *)
-      Test.make ~name:"parallel_pop_opt_push"
-        (pair small_nat small_nat) (fun (npush1, npush2) ->
+      Test.make ~name:"parallel_pop_opt_push" (pair small_nat small_nat)
+        (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
           let barrier = Barrier.create 2 in
@@ -202,8 +202,8 @@ let tests_two_domains =
          Two domains randomly pushs and pops in parallel. They stop as
          soon as they have finished pushing a list of element to
          push. *)
-      Test.make ~name:"parallel_pop_opt_push_random"
-        (pair small_nat small_nat) (fun (npush1, npush2) ->
+      Test.make ~name:"parallel_pop_opt_push_random" (pair small_nat small_nat)
+        (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
           let barrier = Barrier.create 2 in

--- a/test/michael_scott_queue/qcheck_michael_scott_queue.ml
+++ b/test/michael_scott_queue/qcheck_michael_scott_queue.ml
@@ -13,7 +13,7 @@ let tests_sequential =
           (* Testing property *)
           not (is_empty queue));
       (* TEST 2 - push, pop until empty *)
-      Test.make ~name:"push_pop_until_empty" (list int) (fun lpush ->
+      Test.make ~name:"push_pop_opt_until_empty" (list int) (fun lpush ->
           (* Building a random queue *)
           let queue = create () in
           List.iter (push queue) lpush;
@@ -22,12 +22,12 @@ let tests_sequential =
           let count = ref 0 in
           while not (is_empty queue) do
             incr count;
-            ignore (pop queue)
+            ignore (pop_opt queue)
           done;
 
           (* Testing property *)
-          pop queue = None && !count = List.length lpush);
-      (* TEST 3 - push, pop, check FIFO  *)
+          pop_opt queue = None && !count = List.length lpush);
+      (* TEST 3 - push, pop_opt, check FIFO  *)
       Test.make ~name:"fifo" (list int) (fun lpush ->
           (* Building a random queue *)
           let queue = create () in
@@ -37,33 +37,59 @@ let tests_sequential =
           let insert v = out := v :: !out in
 
           for _ = 1 to List.length lpush do
-            match pop queue with None -> assert false | Some v -> insert v
+            match pop_opt queue with None -> assert false | Some v -> insert v
           done;
 
           (* Testing property *)
           lpush = List.rev !out);
+      (* TEST 3 - push, pop_opt, peek_opt check FIFO  *)
+      Test.make ~name:"fifo_peek_opt" (list int) (fun lpush ->
+          (* Building a random queue *)
+          let queue = create () in
+          List.iter (push queue) lpush;
+
+          let pop = ref [] in
+          let peek = ref [] in
+          let insert out v = out := v :: !out in
+
+          for _ = 1 to List.length lpush do
+            match peek_opt queue with
+            | None -> assert false
+            | Some v -> (
+                insert peek v;
+                match pop_opt queue with
+                | None -> assert false
+                | Some v -> insert pop v)
+          done;
+
+          (* Testing property *)
+          lpush = List.rev !pop && lpush = List.rev !peek);
     ]
 
 let tests_one_consumer_one_producer =
   QCheck.
     [
       (* TEST 1 - one consumer one producer:
-         Parallel [push] and [pop]. *)
-      Test.make ~count:10_000 ~name:"parallel_fifo" (list int) (fun lpush ->
+         Parallel [push] and [pop_opt]. *)
+      Test.make ~name:"parallel_fifo" (list int) (fun lpush ->
           (* Initialization *)
           let queue = create () in
+          let barrier = Barrier.create 2 in
 
           (* Producer pushes. *)
           let producer =
-            Domain.spawn (fun () -> List.iter (push queue) lpush)
+            Domain.spawn (fun () ->
+                Barrier.await barrier;
+                List.iter (push queue) lpush)
           in
 
+          Barrier.await barrier;
           let fifo =
             List.fold_left
               (fun acc item ->
                 let popped = ref None in
                 while Option.is_none !popped do
-                  popped := pop queue
+                  popped := pop_opt queue
                 done;
                 acc && item = Option.get !popped)
               true lpush
@@ -73,15 +99,52 @@ let tests_one_consumer_one_producer =
           (* Ensure nothing is left behind. *)
           Domain.join producer;
           fifo && empty);
+      (* TEST 2 - one consumer one producer:
+         Parallel [push] and [peek_opt] and [pop_opt]. *)
+      Test.make ~name:"parallel_peek" (list int) (fun pushed ->
+          (* Initialization *)
+          let npush = List.length pushed in
+          let queue = create () in
+          let barrier = Barrier.create 2 in
+
+          (* Producer pushes. *)
+          let producer =
+            Domain.spawn (fun () ->
+                Barrier.await barrier;
+                List.iter (push queue) pushed)
+          in
+
+          let peeked = ref [] in
+          let popped = ref [] in
+          Barrier.await barrier;
+          for _ = 1 to npush do
+            peeked := peek_opt queue :: !peeked;
+            popped := pop_opt queue :: !popped
+          done;
+
+          Domain.join producer;
+          let rec check = function
+            | _, [], [] -> true
+            | pushed, None :: peeked, None :: popped ->
+                check (pushed, peeked, popped)
+            | push :: pushed, None :: peeked, Some pop :: popped when push = pop
+              ->
+                check (pushed, peeked, popped)
+            | push :: pushed, Some peek :: peeked, Some pop :: popped
+              when push = peek && push = pop ->
+                check (pushed, peeked, popped)
+            | _, _, _ -> false
+          in
+          check (pushed, List.rev @@ !peeked, List.rev @@ !popped));
     ]
 
 let tests_two_domains =
   QCheck.
     [
-      (* TEST 1 - two domains doing multiple times one push then one pop.
-         Parallel [push] and [pop].
+      (* TEST 1 - two domains doing multiple times one push then one pop_opt.
+         Parallel [push] and [pop_opt].
       *)
-      Test.make ~count:10_000 ~name:"parallel_pop_push"
+      Test.make ~name:"parallel_pop_opt_push"
         (pair small_nat small_nat) (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
@@ -97,7 +160,7 @@ let tests_two_domains =
               (fun elt ->
                 push queue elt;
                 Domain.cpu_relax ();
-                pop queue)
+                pop_opt queue)
               lpush
           in
 
@@ -134,12 +197,12 @@ let tests_two_domains =
           all_elt_in && is_sorted push1_pop1 && is_sorted push1_pop2
           && is_sorted push2_pop1 && is_sorted push2_pop2);
       (* TEST 2 -
-         Parallel [push] and [pop] with two domains
+         Parallel [push] and [pop_opt] with two domains
 
          Two domains randomly pushs and pops in parallel. They stop as
          soon as they have finished pushing a list of element to
          push. *)
-      Test.make ~count:10_000 ~name:"parallel_pop_push_random"
+      Test.make ~name:"parallel_pop_opt_push_random"
         (pair small_nat small_nat) (fun (npush1, npush2) ->
           (* Initialization *)
           let queue = create () in
@@ -163,7 +226,7 @@ let tests_two_domains =
                     loop xs popped)
               else (
                 incr consecutive_pop;
-                let p = pop queue in
+                let p = pop_opt queue in
                 loop lpush (p :: popped))
             in
             loop lpush []
@@ -193,7 +256,7 @@ let tests_two_domains =
           (* Pop everything that is still on the queue *)
           let popped3 =
             let rec loop popped =
-              match pop queue with
+              match pop_opt queue with
               | None -> popped
               | Some v -> loop (v :: popped)
             in

--- a/test/mpsc_queue/mpsc_queue_dscheck.ml
+++ b/test/mpsc_queue/mpsc_queue_dscheck.ml
@@ -2,7 +2,7 @@ let drain queue =
   let remaining = ref 0 in
   while not (Mpsc_queue.is_empty queue) do
     remaining := !remaining + 1;
-    assert (Option.is_some (Mpsc_queue.pop queue))
+    assert (Option.is_some (Mpsc_queue.pop_opt queue))
   done;
   !remaining
 
@@ -22,7 +22,7 @@ let producer_consumer () =
       Atomic.spawn (fun () ->
           Mpsc_queue.push_head queue 1;
           for _ = 1 to items_total do
-            match Mpsc_queue.pop queue with
+            match Mpsc_queue.pop_opt queue with
             | None -> ()
             | Some _ -> popped := !popped + 1
           done);
@@ -32,6 +32,47 @@ let producer_consumer () =
           Atomic.check (fun () ->
               let remaining = drain queue in
               !popped + remaining = items_total)))
+
+let producer_consumer_peek () =
+  Atomic.trace (fun () ->
+      let queue = Mpsc_queue.create () in
+      let items_total = 1 in
+      let pushed = List.init items_total (fun i -> i) in
+
+      (* producer *)
+      Atomic.spawn (fun () ->
+          List.iter (fun elt -> Mpsc_queue.push queue elt) pushed);
+
+      (* consumer *)
+      let popped = ref [] in
+      let peeked = ref [] in
+      Atomic.spawn (fun () ->
+          for _ = 1 to items_total do
+            peeked := Mpsc_queue.peek_opt queue :: !peeked;
+            popped := Mpsc_queue.pop_opt queue :: !popped
+          done);
+
+      (* checks*)
+      Atomic.final (fun () ->
+          Atomic.check (fun () ->
+              let rec check pushed peeked popped =
+                match (pushed, peeked, popped) with
+                | _, [], [] -> true
+                | _, None :: peeked, None :: popped ->
+                    check pushed peeked popped
+                | push :: pushed, None :: peeked, Some pop :: popped
+                  when push = pop ->
+                    check pushed peeked popped
+                | push :: pushed, Some peek :: peeked, Some pop :: popped
+                  when push = peek && push = pop ->
+                    check pushed peeked popped
+                | _, _, _ -> false
+              in
+              check pushed (List.rev !peeked) (List.rev !popped));
+          Atomic.check (fun () ->
+              let remaining = drain queue in
+              let popped = List.filter Option.is_some !popped in
+              List.length popped + remaining = items_total)))
 
 let two_producers () =
   Atomic.trace (fun () ->
@@ -59,6 +100,7 @@ let () =
       ( "basic",
         [
           test_case "1-producer-1-consumer" `Slow producer_consumer;
+          test_case "1-producer-1-consumer-peek" `Slow producer_consumer_peek;
           test_case "2-producers" `Slow two_producers;
         ] );
     ]

--- a/test/mpsc_queue/stm_mpsc_queue.ml
+++ b/test/mpsc_queue/stm_mpsc_queue.ml
@@ -6,12 +6,13 @@ open Util
 module Mpsc_queue = Saturn.Single_consumer_queue
 
 module MPSCConf = struct
-  type cmd = Push of int | Pop | Push_head of int | Is_empty | Close
+  type cmd = Push of int | Pop | Peek | Push_head of int | Is_empty | Close
 
   let show_cmd c =
     match c with
     | Push i -> "Push " ^ string_of_int i
     | Pop -> "Pop"
+    | Peek -> "Peek"
     | Push_head i -> "Push_head" ^ string_of_int i
     | Is_empty -> "Is_empty"
     | Close -> "Close"
@@ -35,6 +36,8 @@ module MPSCConf = struct
       (Gen.oneof
          [
            Gen.return Pop;
+           Gen.return Peek;
+           Gen.map (fun i -> Push i) int_gen;
            Gen.map (fun i -> Push_head i) int_gen;
            Gen.return Is_empty;
            Gen.return Close;
@@ -50,7 +53,8 @@ module MPSCConf = struct
         (is_closed, if not is_closed then i :: List.rev s |> List.rev else s)
     | Push_head i -> (is_closed, if not (is_closed && s = []) then i :: s else s)
     | Is_empty -> (is_closed, s)
-    | Pop -> (is_closed, match s with [] -> s | _ :: s' -> s')
+    | Pop -> ( (is_closed, match s with [] -> s | _ :: s' -> s'))
+    | Peek -> (is_closed, s)
     | Close -> (true, s)
 
   let precond _ _ = true
@@ -58,7 +62,8 @@ module MPSCConf = struct
   let run c d =
     match c with
     | Push i -> Res (result unit exn, protect (fun d -> Mpsc_queue.push d i) d)
-    | Pop -> Res (result (option int) exn, protect Mpsc_queue.pop d)
+    | Pop -> Res (result int exn, protect Mpsc_queue.pop d)
+    | Peek -> Res (result int exn, protect Mpsc_queue.peek d)
     | Push_head i ->
         Res (result unit exn, protect (fun d -> Mpsc_queue.push_head d i) d)
     | Is_empty -> Res (result bool exn, protect Mpsc_queue.is_empty d)
@@ -71,11 +76,12 @@ module MPSCConf = struct
     | Push_head _, Res ((Result (Unit, Exn), _), res) ->
         if is_closed && s = [] then res = Error Mpsc_queue.Closed
         else res = Ok ()
-    | Pop, Res ((Result (Option Int, Exn), _), res) -> (
+    | (Pop | Peek), Res ((Result (Int, Exn), _), res) -> (
         match s with
         | [] ->
-            if is_closed then res = Error Mpsc_queue.Closed else res = Ok None
-        | x :: _ -> res = Ok (Some x))
+            if is_closed then res = Error Mpsc_queue.Closed
+            else res = Error Mpsc_queue.Empty
+        | x :: _ -> res = Ok x)
     | Is_empty, Res ((Result (Bool, Exn), _), res) ->
         if is_closed && s = [] then res = Error Mpsc_queue.Closed
         else res = Ok (s = [])

--- a/test/mpsc_queue/stm_mpsc_queue.ml
+++ b/test/mpsc_queue/stm_mpsc_queue.ml
@@ -53,7 +53,7 @@ module MPSCConf = struct
         (is_closed, if not is_closed then i :: List.rev s |> List.rev else s)
     | Push_head i -> (is_closed, if not (is_closed && s = []) then i :: s else s)
     | Is_empty -> (is_closed, s)
-    | Pop -> ( (is_closed, match s with [] -> s | _ :: s' -> s'))
+    | Pop -> (is_closed, match s with [] -> s | _ :: s' -> s')
     | Peek -> (is_closed, s)
     | Close -> (true, s)
 

--- a/test/spsc_queue/qcheck_spsc_queue.ml
+++ b/test/spsc_queue/qcheck_spsc_queue.ml
@@ -3,13 +3,25 @@ module Spsc_queue = Saturn.Single_prod_single_cons_queue
 let keep_some l = List.filter Option.is_some l |> List.map Option.get
 let keep_n_first n = List.filteri (fun i _ -> i < n)
 
+let pop_opt_n_times q n =
+  let rec loop count acc =
+    if count = 0 then acc
+    else
+      let v = Spsc_queue.pop_opt q in
+      Domain.cpu_relax ();
+      loop (count - 1) (v :: acc)
+  in
+  loop n [] |> List.rev
+
 let pop_n_times q n =
   let rec loop count acc =
     if count = 0 then acc
     else
-      let v = Spsc_queue.pop q in
-      Domain.cpu_relax ();
-      loop (count - 1) (v :: acc)
+      try
+        let v = Spsc_queue.pop q in
+        Domain.cpu_relax ();
+        loop (count - 1) (Some v :: acc)
+      with Spsc_queue.Empty -> loop (count - 1) (None :: acc)
   in
   loop n [] |> List.rev
 
@@ -18,6 +30,38 @@ let tests =
     (* TEST 1 - one producer, one consumer:
        Sequential pushes then pops. Checks that the behaviour is similar to
        one of a FIFO queue. *)
+    QCheck.(
+      Test.make ~name:"seq_pop_opt_push"
+        (pair (list int) small_nat)
+        (fun (l, npop) ->
+          (* Making sure we do not create a too big queue. Other
+             tests are checking the behaviour of a full queue.*)
+          let size_exponent = 8 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (List.length l < size_max);
+
+          (* Initialization *)
+          let q = Spsc_queue.create ~size_exponent in
+
+          (* Sequential pushed : not Full exception should be
+             raised. *)
+          let not_full_queue =
+            try
+              List.iter (Spsc_queue.push q) l;
+              true
+            with Spsc_queue.Full -> false
+          in
+
+          (* Consumer domain pops *)
+          let consumer = Domain.spawn (fun () -> pop_opt_n_times q npop) in
+          let pops = Domain.join consumer in
+
+          (* Property *)
+          not_full_queue
+          && List.length pops = npop
+          && keep_some pops = keep_n_first (min (List.length l) npop) l));
+    (* TEST 1b - one producer, one consumer:
+       Same than previous with pop instead of pop_opt *)
     QCheck.(
       Test.make ~name:"seq_pop_push"
         (pair (list int) small_nat)
@@ -48,6 +92,33 @@ let tests =
           not_full_queue
           && List.length pops = npop
           && keep_some pops = keep_n_first (min (List.length l) npop) l));
+    (* TEST 1b - one producer, one consumer:
+       Same than TEST1 with try_push instead of push *)
+    QCheck.(
+      Test.make ~name:"seq_pop_try_push"
+        (pair (list int) small_nat)
+        (fun (l, npop) ->
+          (* Making sure we do not create a too big queue. Other
+             tests are checking the behaviour of a full queue.*)
+          let size_exponent = 8 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (List.length l < size_max);
+
+          (* Initialization *)
+          let q = Spsc_queue.create ~size_exponent in
+
+          (* Sequential pushed : [try_push] should always returns
+             true. *)
+          let not_full_queue = List.for_all (Spsc_queue.try_push q) l in
+
+          (* Consumer domain pops *)
+          let consumer = Domain.spawn (fun () -> pop_opt_n_times q npop) in
+          let pops = Domain.join consumer in
+
+          (* Property *)
+          not_full_queue
+          && List.length pops = npop
+          && keep_some pops = keep_n_first (min (List.length l) npop) l));
     (* TEST 2 - one producer, one consumer:
        Parallel pushes and pops. Checks that the behaviour is similar to
        one of a FIFO queue. *)
@@ -70,7 +141,7 @@ let tests =
           let consumer =
             Domain.spawn (fun () ->
                 Barrier.await barrier;
-                pop_n_times q npop)
+                pop_opt_n_times q npop)
           in
 
           let producer =
@@ -92,7 +163,7 @@ let tests =
           List.length popped = npop
           && popped_val = keep_n_first (List.length popped_val) (l @ l')));
     (* TEST 3 - one producer, one consumer:
-       Checks that pushing too much raise exception Full. *)
+       Checks that pushing too many elements raise exception Full. *)
     QCheck.(
       Test.make ~name:"push_full" (list int) (fun l ->
           let size_exponent = 4 in
@@ -110,6 +181,130 @@ let tests =
           (* Property *)
           (List.length l > size_max && is_full)
           || (List.length l <= size_max && not is_full)));
+    (* TEST 4 - one producer, one consumer:
+        Sequential checks that [peek_opt] read the next value. *)
+    QCheck.(
+      Test.make ~name:"seq_peek_opt" (list int) (fun l ->
+          let size_exponent = 10 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (size_max > List.length l);
+
+          (* Initialisation : pushing l in a new spsc queue. *)
+          let q = Spsc_queue.create ~size_exponent in
+          List.iter (Spsc_queue.push q) l;
+
+          (* Test : we consecutively peek and pop and check both
+             matches with pushed elements. *)
+          let rec loop pushed =
+            match (pushed, Spsc_queue.peek_opt q) with
+            | [], None -> (
+                match Spsc_queue.pop_opt q with None -> true | Some _ -> false)
+            | x :: pushed, Some y when x = y -> (
+                match Spsc_queue.pop_opt q with
+                | None -> false
+                | Some z when y = z -> loop pushed
+                | _ -> false)
+            | _, _ -> false
+          in
+          loop l));
+    (* TEST 4b - one producer, one consumer:
+        Same then previous one for [peek] instead of [peek_one]. *)
+    QCheck.(
+      Test.make ~name:"seq_peek" (list int) (fun l ->
+          let size_exponent = 10 in
+          let size_max = Int.shift_left 1 size_exponent in
+          assume (size_max > List.length l);
+
+          (* Initialisation : pushing l in a new spsc queue. *)
+          let q = Spsc_queue.create ~size_exponent in
+          List.iter (Spsc_queue.push q) l;
+
+          (* Test : we consecutively peek and pop and check both
+             matches with pushed elements. *)
+          let rec loop pushed =
+            let peeked =
+              try Some (Spsc_queue.peek q) with Spsc_queue.Empty -> None
+            in
+            match (pushed, peeked) with
+            | [], None -> (
+                match Spsc_queue.pop_opt q with None -> true | Some _ -> false)
+            | x :: pushed, Some y when x = y -> (
+                match Spsc_queue.pop_opt q with
+                | None -> false
+                | Some z when y = z -> loop pushed
+                | _ -> false)
+            | _, _ -> false
+          in
+          loop l));
+    (* TEST 5 - one producer, one consumer:
+        Parallel test of [peek_opt] with [try_push]. *)
+    QCheck.(
+      Test.make ~name:"par_peek_opt" (list int) (fun pushed ->
+          let size_exponent = 10 in
+          let size_max = Int.shift_left 1 size_exponent in
+          let npush = List.length pushed in
+          assume (size_max > npush);
+          let barrier = Barrier.create 2 in
+
+          (* Initialisation : pushing l in a new spsc queue. *)
+          let q = Spsc_queue.create ~size_exponent in
+
+          (* Test :
+             - domain1 pushes a list of element
+             - in parallel, domain2 peeks then pops. *)
+          let domain1 =
+            Domain.spawn (fun () ->
+                Barrier.await barrier;
+                List.iter
+                  (fun elt ->
+                    Domain.cpu_relax ();
+                    Spsc_queue.push q elt)
+                  pushed)
+          in
+
+          let domain2 =
+            Domain.spawn (fun () ->
+                let peeked = ref [] in
+                let popped = ref [] in
+                Barrier.await barrier;
+                for _ = 0 to npush - 1 do
+                  Domain.cpu_relax ();
+                  (* peek then pop *)
+                  let peek = Spsc_queue.peek_opt q in
+                  let pop = Spsc_queue.pop_opt q in
+                  peeked := peek :: !peeked;
+                  popped := pop :: !popped
+                done;
+                (!peeked, !popped))
+          in
+          Domain.join domain1;
+          let peeked, popped = Domain.join domain2 in
+          let peeked = List.rev peeked in
+          let popped = List.rev popped in
+
+          let rec check pushed peeked popped =
+            match (pushed, peeked, popped) with
+            | _, [], [] ->
+                (* pushed can not be empty if the consumer
+                   finished before the producer *)
+                true
+            | _, None :: peeked, None :: popped ->
+                (* consumer tries to peek then pop when the queue was empty *)
+                check pushed peeked popped
+            | push :: pushed, Some peek :: peeked, Some pop :: popped
+              when push = pop && push = peek ->
+                (* consumer peeks and pops on an non-empty queue. The
+                   peeked and the popped element must be the same. *)
+                check pushed peeked popped
+            | push :: pushed, None :: peeked, Some pop :: popped when push = pop
+              ->
+                (* consumer peeks when the queue was empty, then
+                   producer pushes at least once and then consumer
+                   pops. *)
+                check pushed peeked popped
+            | _, _, _ -> false
+          in
+          check pushed peeked popped));
   ]
 
 let main () =

--- a/test/spsc_queue/spsc_queue_dscheck.ml
+++ b/test/spsc_queue/spsc_queue_dscheck.ml
@@ -5,7 +5,7 @@ let create_test ~shift_by () =
   (* shift the queue, that helps testing overlap handling *)
   for _ = 1 to shift_by do
     Spsc_queue.push queue (-1);
-    assert (Option.is_some (Spsc_queue.pop queue))
+    assert (Option.is_some (Spsc_queue.pop_opt queue))
   done;
 
   (* enqueuer *)
@@ -18,10 +18,12 @@ let create_test ~shift_by () =
   let dequeued = ref 0 in
   Atomic.spawn (fun () ->
       for _ = 1 to items_count + 1 do
-        match Spsc_queue.pop queue with
-        | None -> ()
-        | Some v ->
+        let peeked = Spsc_queue.peek_opt queue in
+        match Spsc_queue.pop_opt queue with
+        | None -> assert (peeked = None)
+        | Some v as popped ->
             assert (v = !dequeued + 1);
+            assert (popped = peeked || peeked = None);
             dequeued := v
       done);
 
@@ -44,7 +46,7 @@ let size_linearizes_with_1_thr () =
 
       let size = ref 0 in
       Atomic.spawn (fun () ->
-          assert (Option.is_some (Spsc_queue.pop queue));
+          assert (Option.is_some (Spsc_queue.pop_opt queue));
           size := Spsc_queue.size queue);
 
       Atomic.final (fun () -> Atomic.check (fun () -> 1 <= !size && !size <= 5)))

--- a/test/spsc_queue/test_spsc_queue.ml
+++ b/test/spsc_queue/test_spsc_queue.ml
@@ -3,7 +3,7 @@ module Spsc_queue = Saturn.Single_prod_single_cons_queue
 
 let test_empty () =
   let q = Spsc_queue.create ~size_exponent:3 in
-  assert (Option.is_none (Spsc_queue.pop q));
+  assert (Option.is_none (Spsc_queue.pop_opt q));
   assert (Spsc_queue.size q == 0);
   print_string "test_spsc_queue_empty: ok\n"
 
@@ -39,13 +39,13 @@ let test_parallel () =
   (* consumer *)
   let last_num = ref 0 in
   while !last_num < count do
-    match Spsc_queue.pop q with
+    match Spsc_queue.pop_opt q with
     | None -> ()
     | Some v ->
         assert (v == !last_num + 1);
         last_num := v
   done;
-  assert (Option.is_none (Spsc_queue.pop q));
+  assert (Option.is_none (Spsc_queue.pop_opt q));
   assert (Spsc_queue.size q == 0);
   Domain.join producer;
   Printf.printf "test_spsc_queue_parallel: ok (transferred = %d)\n" !last_num

--- a/test/treiber_stack/stm_treiber_stack.ml
+++ b/test/treiber_stack/stm_treiber_stack.ml
@@ -41,14 +41,16 @@ module TSConf = struct
   let run c d =
     match c with
     | Push i -> Res (unit, Treiber_stack.push d i)
-    | Pop -> Res (option int, Treiber_stack.pop d)
+    | Pop -> Res (result int exn, protect Treiber_stack.pop d)
     | Is_empty -> Res (bool, Treiber_stack.is_empty d)
 
   let postcond c (s : state) res =
     match (c, res) with
     | Push _, Res ((Unit, _), _) -> true
-    | Pop, Res ((Option Int, _), res) -> (
-        match s with [] -> res = None | j :: _ -> res = Some j)
+    | Pop, Res ((Result (Int, Exn), _), res) -> (
+        match s with
+        | [] -> res = Error Treiber_stack.Empty
+        | j :: _ -> res = Ok j)
     | Is_empty, Res ((Bool, _), res) -> res = (s = [])
     | _, _ -> false
 end

--- a/test/treiber_stack/treiber_stack_dscheck.ml
+++ b/test/treiber_stack/treiber_stack_dscheck.ml
@@ -2,7 +2,7 @@ let drain stack =
   let remaining = ref 0 in
   while not (Treiber_stack.is_empty stack) do
     remaining := !remaining + 1;
-    assert (Option.is_some (Treiber_stack.pop stack))
+    assert (Option.is_some (Treiber_stack.pop_opt stack))
   done;
   !remaining
 
@@ -21,7 +21,7 @@ let producer_consumer () =
       let popped = ref 0 in
       Atomic.spawn (fun () ->
           for _ = 1 to items_total do
-            match Treiber_stack.pop stack with
+            match Treiber_stack.pop_opt stack with
             | None -> ()
             | Some _ -> popped := !popped + 1
           done);
@@ -51,7 +51,7 @@ let two_producers () =
           let rec get_items s =
             if Treiber_stack.is_empty s then []
             else
-              let item = Option.get (Treiber_stack.pop s) in
+              let item = Option.get (Treiber_stack.pop_opt s) in
               item :: get_items s
           in
           let items = get_items stack in
@@ -81,7 +81,7 @@ let two_consumers () =
           Atomic.spawn (fun () ->
               for _ = 1 to items_total / 2 do
                 (* even nums belong to thr 1, odd nums to thr 2 *)
-                list := Option.get (Treiber_stack.pop stack) :: !list
+                list := Option.get (Treiber_stack.pop_opt stack) :: !list
               done)
           |> ignore)
         lists;
@@ -117,7 +117,7 @@ let two_domains () =
                 (fun elt ->
                   (* even nums belong to thr 1, odd nums to thr 2 *)
                   Treiber_stack.push stack elt;
-                  lpop := Option.get (Treiber_stack.pop stack) :: !lpop)
+                  lpop := Option.get (Treiber_stack.pop_opt stack) :: !lpop)
                 lpush)
           |> ignore)
         lists;
@@ -154,8 +154,8 @@ let two_domains_more_pop () =
               List.iter
                 (fun elt ->
                   Treiber_stack.push stack elt;
-                  lpop := Treiber_stack.pop stack :: !lpop;
-                  lpop := Treiber_stack.pop stack :: !lpop)
+                  lpop := Treiber_stack.pop_opt stack :: !lpop;
+                  lpop := Treiber_stack.pop_opt stack :: !lpop)
                 lpush)
           |> ignore)
         lists;


### PR DESCRIPTION
This PR renames and adds functions to the single consumer single producer queue, the michael-scott queue, the treiber stack and the multiple producer single consumer queue. 
- `pop` is renamed `pop_opt` 
- the new `pop`  raises `Empty` if the queue is empty
- `peek` and `peek_opt` have been added as well (except for the stack)

Other notes :
- About work stealing deque : I did not add the `peek` functions, as it seems useless (it is useful mostly with a single consumer). 
- About michael-scott queue : I removed `clean_until` function as it was no atomic. 

TODO : 
- [x] ~Rename `pop` to `pop_opt` for relaxed-queue~,    
- [x] Rename `pop` to `pop_opt` for the work-stealing deque
- [x] Answer the question :  should `pop` and `pop_opt` be almost copy-paste function or should we use the  `inline` keyword (see comment in code)