### PR TITLE
Remove 'name' field from benchmark results

### DIFF
--- a/bench/main.ml
+++ b/bench/main.ml
@@ -27,7 +27,7 @@ let () =
     |> String.concat ", "
   in
   let output =
-    Printf.sprintf {| {"name": "saturn", "results": [%s]}|} results
+    Printf.sprintf {|{"results": [%s]}|} results
     (* Cannot use Yojson rewriters as of today none works on OCaml 5.1.0.
        This at least verifies that the manually crafted JSON is well-formed.
 


### PR DESCRIPTION
@punchagan pointed out that the current-bench interface is adding another level of abstraction as the top-level json has a name field. Revoming this would get the results to show up on the front-page of the current-bench run.