### PR TITLE
Add missing alcotest with-test dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,6 +13,7 @@
   (ocaml (>= 4.12))
   (domain_shims (>= 0.1.0))
   (saturn_lockfree (= :version))
+  (alcotest (and (>= 1.7.0) :with-test))
   (qcheck (and (>= 0.18.1) :with-test))
   (qcheck-stm (and (>= 0.2) :with-test))
   (qcheck-alcotest (and (>= 0.18.1) :with-test))
@@ -24,6 +25,7 @@
  (depends
   (ocaml (>= 4.12))
   (domain_shims (>= 0.1.0))
+  (alcotest (and (>= 1.7.0) :with-test))
   (qcheck (and (>= 0.18.1) :with-test))
   (qcheck-stm (and (>= 0.2) :with-test))
   (qcheck-alcotest (and (>= 0.18.1) :with-test))

--- a/saturn.opam
+++ b/saturn.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "domain_shims" {>= "0.1.0"}
   "saturn_lockfree" {= version}
+  "alcotest" {>= "1.7.0" & with-test}
   "qcheck" {>= "0.18.1" & with-test}
   "qcheck-stm" {>= "0.2" & with-test}
   "qcheck-alcotest" {>= "0.18.1" & with-test}

--- a/saturn_lockfree.opam
+++ b/saturn_lockfree.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.12"}
   "domain_shims" {>= "0.1.0"}
+  "alcotest" {>= "1.7.0" & with-test}
   "qcheck" {>= "0.18.1" & with-test}
   "qcheck-stm" {>= "0.2" & with-test}
   "qcheck-alcotest" {>= "0.18.1" & with-test}


### PR DESCRIPTION
The experimental `(lint-opam)` ocaml-ci check complains ❌ :

```
saturn.opam: changes needed:
  "alcotest" {with-test & >= "0"}          [from test/michael_scott_queue, test/mpmc_relaxed_queue, test/mpsc_queue, test/spsc_queue, test/treiber_stack, test/ws_deque]
saturn_lockfree.opam: changes needed:
  "alcotest" {with-test & >= "0"}          [from test/michael_scott_queue, test/mpmc_relaxed_queue, test/mpsc_queue, test/spsc_queue, test/treiber_stack, test/ws_deque]
```

This PR adds the missing alcotest dependency and makes `(lint-opam)` happy ✅.