### PR TITLE
Upgrade to ocamlformat 0.26.1 and set `exp-grouping=preserve`

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,4 @@
 profile = default
-version = 0.26.0
+version = 0.26.1
+
+exp-grouping=preserve


### PR DESCRIPTION
This PR upgrades ocamlformat to the latest version 0.26.1 and adds `exp-grouping=preserve` to the configuration.

Here is what the man page says on `exp-grouping`:

```
--exp-grouping={parens|preserve}
    Style of expression grouping. parens groups expressions using parentheses. preserve preserves
    the original grouping syntax (parentheses or begin/end). The default value is parens. Cannot
    be set in attributes.
```

In other words, `exp-grouping=preserve` allows one to explicitly use `begin ... end` instead of `( ... )`.  The default is to always use `( ... )`.

I've been using `exp-grouping=preserve` in several projects, because I find that using `begin ... ; ... end` for grouping statements/blocks is visually clearer (easier and faster to read).  I don't think that it should be controversial that `begin ... ; ... end` is easier to spot visually than `( ... ; ... )`.  What could be controversial is that `exp-grouping=preserve` is not the default of ocamlformat, some people might find `begin ... ; ... end` "uglier", and having the option could lead to formatting wars (i.e. people changing formatting back and forth). I personally don't believe those are significant enough reasons to force code to be visually subtler in a library like this, with very high requirements for correctness.  Ultimately this is not a purely technical matter.