### PR TITLE
Fix odoc warning and `raise` syntax

### DIFF
--- a/src_lockfree/treiber_stack.mli
+++ b/src_lockfree/treiber_stack.mli
@@ -16,7 +16,7 @@ val push : 'a t -> 'a -> unit
 (** [push s v] adds the element [v] at the top of stack [s]. *)
 
 exception Empty
-(** Raised when {!pop} or {!peek} is applied to an empty queue. *)
+(** Raised when {!pop} is applied to an empty queue. *)
 
 val pop : 'a t -> 'a
 (** [pop s] removes and returns the topmost element in the

--- a/src_lockfree/ws_deque.mli
+++ b/src_lockfree/ws_deque.mli
@@ -31,7 +31,7 @@ module type S = sig
       [q].It should only be invoked by the domain which owns the queue
       [q].
 
-      @raise [Exit] if the queue is empty.
+      @raise Exit if the queue is empty.
       *)
 
   val pop_opt : 'a t -> 'a option
@@ -45,7 +45,7 @@ module type S = sig
       [q]. It should only be invoked by domain which doesn't own the
       queue [q].
 
-      @raise [Exit] if the queue is empty.
+      @raise Exit if the queue is empty.
   *)
 
   val steal_opt : 'a t -> 'a option


### PR DESCRIPTION
This PR:
* Drops the reference to undefined `peek` in Treiber stack.
* Uses `@raise Exit` instead of `@raise [Exit]` to specify exception raised.