### PR TITLE
Upgrade dscheck dependency to 0.2.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
   (qcheck-stm (and (>= 0.2) :with-test))
   (qcheck-alcotest (and (>= 0.18.1) :with-test))
   (yojson (and (>= 2.0.2) :with-test))
-  (dscheck (and (>= 0.1.0) :with-test))))
+  (dscheck (and (>= 0.2.0) :with-test))))
 (package
  (name saturn_lockfree)
  (synopsis "Collection of lock-free data structures for Multicore OCaml")
@@ -30,4 +30,4 @@
   (qcheck-stm (and (>= 0.2) :with-test))
   (qcheck-alcotest (and (>= 0.18.1) :with-test))
   (yojson (and (>= 2.0.2) :with-test))
-  (dscheck (and (>= 0.1.0) :with-test))))
+  (dscheck (and (>= 0.2.0) :with-test))))

--- a/saturn.opam
+++ b/saturn.opam
@@ -18,7 +18,7 @@ depends: [
   "qcheck-stm" {>= "0.2" & with-test}
   "qcheck-alcotest" {>= "0.18.1" & with-test}
   "yojson" {>= "2.0.2" & with-test}
-  "dscheck" {>= "0.1.0" & with-test}
+  "dscheck" {>= "0.2.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/saturn_lockfree.opam
+++ b/saturn_lockfree.opam
@@ -16,7 +16,7 @@ depends: [
   "qcheck-stm" {>= "0.2" & with-test}
   "qcheck-alcotest" {>= "0.18.1" & with-test}
   "yojson" {>= "2.0.2" & with-test}
-  "dscheck" {>= "0.1.0" & with-test}
+  "dscheck" {>= "0.2.0" & with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
It seems some tests with dscheck 0.1.0 occasionally fail unexpectedly on CI.

Here is a failure on `spsc_queue_dscheck` test where only the first test runs and then something goes wrong as can be inferred by the output from the test ending:

```
File "test/spsc_queue/dune", line 5, characters 7-25:
5 |  (name spsc_queue_dscheck)
           ^^^^^^^^^^^^^^^^^^
(cd _build/default/test/spsc_queue && ./spsc_queue_dscheck.exe)
Testing `Spsc_queue_dscheck'.
This run has ID `04E668A0'.

  [OK]          basic                 0   simple-test.
(cd _build/default/test/michael_scott_queue && ./michael_scott_queue_dscheck.exe)
```

Here is log output from another failure

```
2023-11-16 14:18.57: >>> [FAIL]        basic          0   2-mem. (score = 30)
2023-11-16 14:18.57: >>> [FAIL]        basic          1   2-add-same. (score = 30)
2023-11-16 14:18.57: >>> [FAIL]        basic          2   2-add. (score = 30)
2023-11-16 14:18.57: >>> [FAIL]        basic          3   2-remove-same. (score = 30)
2023-11-16 14:18.57: >>> [FAIL]        basic          4   2-remove. (score = 30)
2023-11-16 14:18.57: >>> [FAIL]        basic          0   2-mem.                                      │ (score = 30)
2023-11-16 14:18.57: >>> [exception] File "src/tracedAtomic.ml", line 193, characters 12-18: Assertion failed (score = 35)
2023-11-16 14:18.57: >>> [FAIL]        basic          1   2-add-same.                                 │ (score = 30)
2023-11-16 14:18.57: >>> [exception] Stdlib.Effect.Unhandled(Dscheck.TracedAtomic.Make(0)) (score = 35)
2023-11-16 14:18.57: >>> [FAIL]        basic          2   2-add.                                      │ (score = 30)
2023-11-16 14:18.57: >>> [exception] Stdlib.Effect.Unhandled(Dscheck.TracedAtomic.Make(0)) (score = 35)
2023-11-16 14:18.57: >>> [FAIL]        basic          3   2-remove-same.                              │ (score = 30)
2023-11-16 14:18.57: >>> [exception] Stdlib.Effect.Unhandled(Dscheck.TracedAtomic.Make(0)) (score = 35)
2023-11-16 14:18.57: >>> [FAIL]        basic          4   2-remove.                                   │ (score = 30)
2023-11-16 14:18.57: >>> [exception] Stdlib.Effect.Unhandled(Dscheck.TracedAtomic.Make(0)) (score = 35)
2023-11-16 14:18.57: Exception: File "src/tracedAtomic.ml", line 193, characters 12-18: Assertion failed
```

which seems to point to a bug within dscheck (an unhandled effect?).