### PR TITLE
Only run GitHub action on push to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ name: main
 on:
   pull_request:
   push:
+    branches:
+      - main
   schedule:
     # Prime the caches every Monday
     - cron: 0 1 * * MON


### PR DESCRIPTION
The action is already run for pull requests.  This change makes it so that PRs don't run the action twice.