### PR TITLE
Execute benchmarks in release mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ clean:
 	dune clean
 
 bench:
-	@dune exec -- ./bench/main.exe
+	@dune exec --release -- ./bench/main.exe


### PR DESCRIPTION
It doesn't typically make a big difference in OCaml to run things in release mode, but let's still run benchmarks in release mode and avoid potential issues later where the benchmark results might be misleading due to not running in release mode.