### PR TITLE
Fix dune rules to specify package

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,6 @@
   (ocaml (>= 4.12))
   (domain_shims (>= 0.1.0))
   (saturn_lockfree (= :version))
-  (backoff (>= 0.1.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (qcheck (and (>= 0.18.1) :with-test))
   (qcheck-stm (and (>= 0.2) :with-test))

--- a/saturn.opam
+++ b/saturn.opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.12"}
   "domain_shims" {>= "0.1.0"}
   "saturn_lockfree" {= version}
-  "backoff" {>= "0.1.0"}
   "alcotest" {>= "1.7.0" & with-test}
   "qcheck" {>= "0.18.1" & with-test}
   "qcheck-stm" {>= "0.2" & with-test}

--- a/test/michael_scott_queue/dune
+++ b/test/michael_scott_queue/dune
@@ -1,7 +1,10 @@
 (rule
- (copy ../../src_lockfree/michael_scott_queue.ml michael_scott_queue.ml))
+ (action
+  (copy ../../src_lockfree/michael_scott_queue.ml michael_scott_queue.ml))
+ (package saturn_lockfree))
 
 (test
+ (package saturn_lockfree)
  (name michael_scott_queue_dscheck)
  (libraries atomic dscheck alcotest backoff)
  (enabled_if
@@ -12,14 +15,16 @@
  (modules michael_scott_queue michael_scott_queue_dscheck))
 
 (test
+ (package saturn_lockfree)
  (name qcheck_michael_scott_queue)
- (libraries saturn barrier qcheck qcheck-alcotest)
+ (libraries saturn_lockfree barrier qcheck qcheck-alcotest)
  (modules qcheck_michael_scott_queue))
 
 (test
+ (package saturn_lockfree)
  (name stm_michael_scott_queue)
  (modules stm_michael_scott_queue)
- (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn_lockfree qcheck-stm.sequential qcheck-stm.domain)
  (enabled_if
   (= %{arch_sixtyfour} true))
  (action

--- a/test/michael_scott_queue/qcheck_michael_scott_queue.ml
+++ b/test/michael_scott_queue/qcheck_michael_scott_queue.ml
@@ -1,4 +1,4 @@
-open Saturn.Queue
+open Saturn_lockfree.Queue
 
 let tests_sequential =
   QCheck.

--- a/test/michael_scott_queue/stm_michael_scott_queue.ml
+++ b/test/michael_scott_queue/stm_michael_scott_queue.ml
@@ -2,7 +2,7 @@
 
 open QCheck
 open STM
-module Ms_queue = Saturn.Queue
+module Ms_queue = Saturn_lockfree.Queue
 
 module MSQConf = struct
   type cmd = Push of int | Pop | Peek | Is_empty
@@ -66,7 +66,7 @@ let () =
   QCheck_base_runner.run_tests_main
     [
       MSQ_seq.agree_test ~count
-        ~name:"STM Saturn.Michael_scott_queue test sequential";
+        ~name:"STM Saturn_lockfree.Michael_scott_queue test sequential";
       MSQ_dom.agree_test_par ~count
-        ~name:"STM Saturn.Michael_scott_queue test parallel";
+        ~name:"STM Saturn_lockfree.Michael_scott_queue test parallel";
     ]

--- a/test/mpmc_relaxed_queue/dune
+++ b/test/mpmc_relaxed_queue/dune
@@ -1,4 +1,5 @@
 (test
+ (package saturn)
  (name test_mpmc_relaxed_queue)
  (libraries saturn unix alcotest)
  (modules test_mpmc_relaxed_queue))

--- a/test/mpmc_relaxed_queue/test_mpmc_relaxed_queue.ml
+++ b/test/mpmc_relaxed_queue/test_mpmc_relaxed_queue.ml
@@ -1,4 +1,4 @@
-open Saturn
+module Relaxed_queue = Saturn.Relaxed_queue
 
 let smoke_test (push, pop) () =
   let queue = Relaxed_queue.create ~size_exponent:2 () in

--- a/test/mpsc_queue/dune
+++ b/test/mpsc_queue/dune
@@ -1,20 +1,25 @@
 (rule
- (copy ../../src_lockfree/mpsc_queue.ml mpsc_queue.ml))
+ (action
+  (copy ../../src_lockfree/mpsc_queue.ml mpsc_queue.ml))
+ (package saturn_lockfree))
 
 (test
+ (package saturn_lockfree)
  (name mpsc_queue_dscheck)
  (libraries atomic dscheck alcotest)
  (modules mpsc_queue mpsc_queue_dscheck))
 
 (test
+ (package saturn_lockfree)
  (name qcheck_mpsc_queue)
- (libraries saturn barrier qcheck qcheck-alcotest)
+ (libraries saturn_lockfree barrier qcheck qcheck-alcotest)
  (modules qcheck_mpsc_queue))
 
 (test
+ (package saturn_lockfree)
  (name stm_mpsc_queue)
  (modules stm_mpsc_queue)
- (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn_lockfree qcheck-stm.sequential qcheck-stm.domain)
  (enabled_if
   (= %{arch_sixtyfour} true))
  (action

--- a/test/mpsc_queue/qcheck_mpsc_queue.ml
+++ b/test/mpsc_queue/qcheck_mpsc_queue.ml
@@ -1,4 +1,4 @@
-module Mpsc_queue = Saturn.Single_consumer_queue
+module Mpsc_queue = Saturn_lockfree.Single_consumer_queue
 
 (* Mpsc_queue is a multiple producers, single consumer queue. *)
 (* Producers can use the functions

--- a/test/mpsc_queue/stm_mpsc_queue.ml
+++ b/test/mpsc_queue/stm_mpsc_queue.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Mpsc_queue = Saturn.Single_consumer_queue
+module Mpsc_queue = Saturn_lockfree.Single_consumer_queue
 
 module MPSCConf = struct
   type cmd = Push of int | Pop | Peek | Push_head of int | Is_empty | Close
@@ -111,8 +111,10 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      MPSC_seq.agree_test ~count ~name:"STM Saturn.Mpsc_queue test sequential";
-      agree_test_par_asym ~count ~name:"STM Saturn.Mpsc_queue test parallel";
+      MPSC_seq.agree_test ~count
+        ~name:"STM Saturn_lockfree.Mpsc_queue test sequential";
+      agree_test_par_asym ~count
+        ~name:"STM Saturn_lockfree.Mpsc_queue test parallel";
       MPSC_dom.neg_agree_test_par ~count
-        ~name:"STM Saturn.Mpsc_queue test parallel, negative";
+        ~name:"STM Saturn_lockfree.Mpsc_queue test parallel, negative";
     ]

--- a/test/seqtest/seqtest.ml
+++ b/test/seqtest/seqtest.ml
@@ -1,5 +1,5 @@
 open Monolith
-open Saturn.Work_stealing_deque
+open Saturn_lockfree.Work_stealing_deque
 
 (* This sequential implementation of stacks serves as a reference. *)
 

--- a/test/spsc_queue/dune
+++ b/test/spsc_queue/dune
@@ -1,25 +1,31 @@
 (rule
- (copy ../../src_lockfree/spsc_queue.ml spsc_queue.ml))
+ (action
+  (copy ../../src_lockfree/spsc_queue.ml spsc_queue.ml))
+ (package saturn_lockfree))
 
 (test
+ (package saturn_lockfree)
  (name spsc_queue_dscheck)
  (libraries atomic dscheck alcotest)
  (modules spsc_queue spsc_queue_dscheck))
 
 (test
+ (package saturn_lockfree)
  (name test_spsc_queue)
- (libraries saturn)
+ (libraries saturn_lockfree)
  (modules test_spsc_queue))
 
 (test
+ (package saturn_lockfree)
  (name qcheck_spsc_queue)
- (libraries saturn barrier qcheck "qcheck-alcotest")
+ (libraries saturn_lockfree barrier qcheck "qcheck-alcotest")
  (modules qcheck_spsc_queue))
 
 (test
+ (package saturn_lockfree)
  (name stm_spsc_queue)
  (modules stm_spsc_queue)
- (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn_lockfree qcheck-stm.sequential qcheck-stm.domain)
  (enabled_if
   (= %{arch_sixtyfour} true))
  (action

--- a/test/spsc_queue/qcheck_spsc_queue.ml
+++ b/test/spsc_queue/qcheck_spsc_queue.ml
@@ -1,4 +1,4 @@
-module Spsc_queue = Saturn.Single_prod_single_cons_queue
+module Spsc_queue = Saturn_lockfree.Single_prod_single_cons_queue
 
 let keep_some l = List.filter Option.is_some l |> List.map Option.get
 let keep_n_first n = List.filteri (fun i _ -> i < n)

--- a/test/spsc_queue/stm_spsc_queue.ml
+++ b/test/spsc_queue/stm_spsc_queue.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Spsc_queue = Saturn.Single_prod_single_cons_queue
+module Spsc_queue = Saturn_lockfree.Single_prod_single_cons_queue
 
 module SPSCConf = struct
   type cmd = Push of int | Pop | Peek
@@ -86,9 +86,11 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      SPSC_seq.agree_test ~count ~name:"STM Saturn.Spsc_queue test sequential";
-      agree_test_par_asym ~count ~name:"STM Saturn.Spsc_queue test parallel";
+      SPSC_seq.agree_test ~count
+        ~name:"STM Saturn_lockfree.Spsc_queue test sequential";
+      agree_test_par_asym ~count
+        ~name:"STM Saturn_lockfree.Spsc_queue test parallel";
       (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
       SPSC_dom.neg_agree_test_par ~count
-        ~name:"STM Saturn.Spsc_queue test parallel, negative";
+        ~name:"STM Saturn_lockfree.Spsc_queue test parallel, negative";
     ]

--- a/test/spsc_queue/test_spsc_queue.ml
+++ b/test/spsc_queue/test_spsc_queue.ml
@@ -1,4 +1,4 @@
-module Spsc_queue = Saturn.Single_prod_single_cons_queue
+module Spsc_queue = Saturn_lockfree.Single_prod_single_cons_queue
 (** Tests *)
 
 let test_empty () =

--- a/test/treiber_stack/dune
+++ b/test/treiber_stack/dune
@@ -1,7 +1,10 @@
 (rule
- (copy ../../src_lockfree/treiber_stack.ml treiber_stack.ml))
+ (action
+  (copy ../../src_lockfree/treiber_stack.ml treiber_stack.ml))
+ (package saturn_lockfree))
 
 (test
+ (package saturn_lockfree)
  (name treiber_stack_dscheck)
  (libraries atomic dscheck alcotest backoff)
  (enabled_if
@@ -12,14 +15,16 @@
  (modules treiber_stack treiber_stack_dscheck))
 
 (test
+ (package saturn_lockfree)
  (name qcheck_treiber_stack)
- (libraries saturn barrier qcheck qcheck-alcotest)
+ (libraries saturn_lockfree barrier qcheck qcheck-alcotest)
  (modules qcheck_treiber_stack))
 
 (test
+ (package saturn_lockfree)
  (name stm_treiber_stack)
  (modules stm_treiber_stack)
- (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn_lockfree qcheck-stm.sequential qcheck-stm.domain)
  (enabled_if
   (= %{arch_sixtyfour} true))
  (action

--- a/test/treiber_stack/qcheck_treiber_stack.ml
+++ b/test/treiber_stack/qcheck_treiber_stack.ml
@@ -1,4 +1,4 @@
-open Saturn.Stack
+open Saturn_lockfree.Stack
 
 let tests_sequential =
   QCheck.

--- a/test/treiber_stack/stm_treiber_stack.ml
+++ b/test/treiber_stack/stm_treiber_stack.ml
@@ -2,7 +2,7 @@
 
 open QCheck
 open STM
-module Treiber_stack = Saturn.Stack
+module Treiber_stack = Saturn_lockfree.Stack
 
 module TSConf = struct
   type cmd = Push of int | Pop | Is_empty
@@ -62,7 +62,8 @@ let () =
   let count = 500 in
   QCheck_base_runner.run_tests_main
     [
-      TS_seq.agree_test ~count ~name:"STM Saturn.Treiber_stack test sequential";
+      TS_seq.agree_test ~count
+        ~name:"STM Saturn_lockfree.Treiber_stack test sequential";
       TS_dom.agree_test_par ~count
-        ~name:"STM Saturn.Treiber_stack test parallel";
+        ~name:"STM Saturn_lockfree.Treiber_stack test parallel";
     ]

--- a/test/ws_deque/dune
+++ b/test/ws_deque/dune
@@ -1,22 +1,29 @@
 (rule
- (copy ../../src_lockfree/ArrayExtra.ml ArrayExtra.ml))
+ (action
+  (copy ../../src_lockfree/ArrayExtra.ml ArrayExtra.ml))
+ (package saturn_lockfree))
 
 (rule
- (copy ../../src_lockfree/ws_deque.ml ws_deque.ml))
+ (action
+  (copy ../../src_lockfree/ws_deque.ml ws_deque.ml))
+ (package saturn_lockfree))
 
 (test
+ (package saturn_lockfree)
  (name ws_deque_dscheck)
  (libraries atomic dscheck alcotest)
  (modules ArrayExtra ws_deque ws_deque_dscheck))
 
 (test
+ (package saturn_lockfree)
  (name test_ws_deque)
- (libraries saturn)
+ (libraries saturn_lockfree)
  (modules test_ws_deque))
 
 (test
+ (package saturn_lockfree)
  (name qcheck_ws_deque)
- (libraries barrier saturn qcheck "qcheck-alcotest")
+ (libraries barrier saturn_lockfree qcheck "qcheck-alcotest")
  (enabled_if
   (not
    (and
@@ -25,9 +32,10 @@
  (modules qcheck_ws_deque))
 
 (test
+ (package saturn_lockfree)
  (name stm_ws_deque)
  (modules stm_ws_deque)
- (libraries saturn qcheck-stm.sequential qcheck-stm.domain)
+ (libraries saturn_lockfree qcheck-stm.sequential qcheck-stm.domain)
  (enabled_if
   (= %{arch_sixtyfour} true))
  (action

--- a/test/ws_deque/qcheck_ws_deque.ml
+++ b/test/ws_deque/qcheck_ws_deque.ml
@@ -1,4 +1,4 @@
-module Ws_deque = Saturn.Work_stealing_deque.M
+module Ws_deque = Saturn_lockfree.Work_stealing_deque.M
 
 (* Sequential building of a deque *)
 let deque_of_list l =

--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -3,7 +3,7 @@
 open QCheck
 open STM
 open Util
-module Ws_deque = Saturn.Work_stealing_deque
+module Ws_deque = Saturn_lockfree.Work_stealing_deque
 
 module WSDConf = struct
   type cmd = Push of int | Pop | Steal
@@ -78,9 +78,11 @@ let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
-      WSDT_seq.agree_test ~count ~name:"STM Saturn.Ws_deque test sequential";
-      agree_test_par_asym ~count ~name:"STM Saturn.Ws_deque test parallel";
+      WSDT_seq.agree_test ~count
+        ~name:"STM Saturn_lockfree.Ws_deque test sequential";
+      agree_test_par_asym ~count
+        ~name:"STM Saturn_lockfree.Ws_deque test parallel";
       (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
       WSDT_dom.neg_agree_test_par ~count
-        ~name:"STM Saturn.Ws_deque test parallel, negative";
+        ~name:"STM Saturn_lockfree.Ws_deque test parallel, negative";
     ]

--- a/test/ws_deque/test_ws_deque.ml
+++ b/test/ws_deque/test_ws_deque.ml
@@ -1,4 +1,4 @@
-open Saturn.Work_stealing_deque.M
+open Saturn_lockfree.Work_stealing_deque.M
 (** Tests *)
 
 let test_empty () =


### PR DESCRIPTION
This PR fixes the dune rules to specify packages for tests such that they are only run for either the `saturn` or the `saturn_lockfree` package and also adjusts the dependencies and references to the data structures in the tests to match.

I wonder... While working on `Kcas` which also has the `Kcas_data` package I ran into the issue that tests failed on opam-ci and I had to fix the dune rules to specify packages.  Didn't this issue in `Saturn` and `Saturn_lockfree` cause tests to fail on opam-ci?  It is a good idea to watch carefully what happens on opam-ci.  Perhaps we should write short instructions for developers on how to publish-to-opam and what to watch for, and to rotate publish-to-opam responsibility.