### PR TITLE
Prefer `Backoff` over `Domain.cpu_relax` and `domain_shims`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -12,7 +12,7 @@
  (synopsis "Collection of parallelism-safe data structures for Multicore OCaml")
  (depends
   (ocaml (>= 4.12))
-  (domain_shims (>= 0.1.0))
+  (domain_shims (and (>= 0.1.0) :with-test))
   (saturn_lockfree (= :version))
   (alcotest (and (>= 1.7.0) :with-test))
   (qcheck (and (>= 0.21.3) :with-test))
@@ -25,7 +25,7 @@
  (synopsis "Collection of lock-free data structures for Multicore OCaml")
  (depends
   (ocaml (>= 4.12))
-  (domain_shims (>= 0.1.0))
+  (domain_shims (and (>= 0.1.0) :with-test))
   (backoff (>= 0.1.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (qcheck (and (>= 0.21.3) :with-test))

--- a/saturn.opam
+++ b/saturn.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.12"}
-  "domain_shims" {>= "0.1.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
   "saturn_lockfree" {= version}
   "alcotest" {>= "1.7.0" & with-test}
   "qcheck" {>= "0.21.3" & with-test}

--- a/saturn_lockfree.opam
+++ b/saturn_lockfree.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.12"}
-  "domain_shims" {>= "0.1.0"}
+  "domain_shims" {>= "0.1.0" & with-test}
   "backoff" {>= "0.1.0"}
   "alcotest" {>= "1.7.0" & with-test}
   "qcheck" {>= "0.21.3" & with-test}

--- a/src_lockfree/dune
+++ b/src_lockfree/dune
@@ -1,4 +1,22 @@
+(* -*- tuareg -*- *)
+
+let maybe_threads =
+  if Jbuild_plugin.V1.ocaml_version < "5" then "threads.posix" else ""
+
+let () =
+  Jbuild_plugin.V1.send
+  @@ {|
+
 (library
  (name saturn_lockfree)
  (public_name saturn_lockfree)
- (libraries domain_shims backoff))
+ (libraries backoff |}
+  ^ maybe_threads
+  ^ {| ))
+
+(rule
+ (enabled_if
+  (< %{ocaml_version} 5.0.0))
+ (action
+  (copy domain.ocaml4.ml domain.ml)))
+|}

--- a/test/ws_deque/dune
+++ b/test/ws_deque/dune
@@ -11,7 +11,7 @@
 (test
  (package saturn_lockfree)
  (name ws_deque_dscheck)
- (libraries atomic dscheck alcotest)
+ (libraries atomic dscheck alcotest backoff)
  (modules ArrayExtra ws_deque ws_deque_dscheck))
 
 (test


### PR DESCRIPTION
This PR replaces a use of `Domain.cpu_relax ()` with `Backoff` and implements a `Domain` module with `cpu_relax = Thread.yield` on OCaml 4.  This allows dropping the dependency to `domain_shims`.  I would recommend not depending on `domain_shims` in cases where the dependency is easy to avoid (except on internal tests, for example).

`domain_shims` currently (implicitly) depends on `threads`, for example, which, I believe, means that it does not directly build with `js_of_ocaml`.  Some of the detailed decisions in `domain_shims` also may not be exactly right for all use cases.  For example, if you want to use `Domain.DLS` to avoid contention, then the implementation in `domain_shims` is not necessarily what you want, because it is fundamentally a `TLS` (thread-local storage) rather than a `DLS` (domain-local storage).