### PR TITLE
Also test with OCaml 5.1.1 on Windows and 4.13.x and 4.14.x as those are supposed to be supported

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ on:
 
 jobs:
   windows:
+    strategy:
+      matrix:
+        ocaml-compiler:
+          - ocaml.5.0.0,ocaml-option-mingw
+          - ocaml.5.1.1,ocaml-option-mingw
+
     runs-on: windows-latest
 
     env:
@@ -33,7 +39,7 @@ jobs:
         with:
           opam-pin: false
           opam-depext: false
-          ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-repositories: |
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
             default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   windows:
     strategy:
+      fail-fast: false
       matrix:
         ocaml-compiler:
           - ocaml.5.0.0,ocaml-option-mingw
@@ -48,6 +49,7 @@ jobs:
 
   build-4_x:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
       QCHECK_MSG_INTERVAL: '60'
 
     steps:
-      - name: Checkout code
+      - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+      - name: Set up OCaml
         uses: ocaml/setup-ocaml@v2
         with:
           opam-pin: false
@@ -37,8 +37,11 @@ jobs:
             default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             upstream: https://github.com/ocaml/opam-repository.git
 
-      - run: opam install . --deps-only --with-test
+      - name: Install dependencies
+        run: opam install . --deps-only --with-test
 
-      - run: opam exec -- dune build
+      - name: Build
+        run: opam exec -- dune build
 
-      - run: opam exec -- dune runtest
+      - name: Test
+        run: opam exec -- dune runtest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Get latest OCaml commit hash
-        id: multicore_hash
-        shell: bash
-        run: |
-          curl -sH "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/ocaml/ocaml/commits/trunk \
-          | jq .commit.tree.sha | xargs printf '::set-output name=commit::%s'
-
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
@@ -44,7 +36,6 @@ jobs:
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
             default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             upstream: https://github.com/ocaml/opam-repository.git
-          cache-prefix: ${{ steps.multicore_hash.outputs.commit }}
 
       - run: opam install . --deps-only --with-test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,31 @@ jobs:
 
       - name: Test
         run: opam exec -- dune runtest
+
+  build-4_x:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.13.x
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          opam-pin: false
+          opam-depext: false
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install dependencies
+        run: opam install . --deps-only
+
+      - name: Build (release)
+        run: opam exec -- dune build --release

--- a/dune-project
+++ b/dune-project
@@ -11,7 +11,7 @@
  (name saturn)
  (synopsis "Collection of parallelism-safe data structures for Multicore OCaml")
  (depends
-  (ocaml (>= 4.12))
+  (ocaml (>= 4.13))
   (domain_shims (and (>= 0.1.0) :with-test))
   (saturn_lockfree (= :version))
   (alcotest (and (>= 1.7.0) :with-test))
@@ -24,7 +24,7 @@
  (name saturn_lockfree)
  (synopsis "Collection of lock-free data structures for Multicore OCaml")
  (depends
-  (ocaml (>= 4.12))
+  (ocaml (>= 4.13))
   (domain_shims (and (>= 0.1.0) :with-test))
   (backoff (>= 0.1.0))
   (alcotest (and (>= 1.7.0) :with-test))

--- a/saturn.opam
+++ b/saturn.opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/saturn/"
 bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.13"}
   "domain_shims" {>= "0.1.0" & with-test}
   "saturn_lockfree" {= version}
   "alcotest" {>= "1.7.0" & with-test}

--- a/saturn_lockfree.opam
+++ b/saturn_lockfree.opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/saturn/"
 bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.13"}
   "domain_shims" {>= "0.1.0" & with-test}
   "backoff" {>= "0.1.0"}
   "alcotest" {>= "1.7.0" & with-test}

--- a/src_lockfree/domain.ocaml4.ml
+++ b/src_lockfree/domain.ocaml4.ml
@@ -1,0 +1,1 @@
+let cpu_relax = Thread.yield


### PR DESCRIPTION
This PR adds a matrix to test on both OCaml 5.0.0 and 5.1.1.

This PR also adds a matrix to build (not test) on OCaml 4.12.x and 4.13.x.
* This uncovered an issue which is that currently Saturn is supposed to build on OCaml 4.12, but, in fact, it depends on backoff, which currently requires OCaml 4.13 ([`Int.min`](https://github.com/ocaml-multicore/backoff/blob/2ffac8ca51a822234b1e47af0430443b9c86cb13/src/backoff.ml#L51) was [added in 4.13](https://v2.ocaml.org/api/Int.html#VALmin)).
* This also uncovered issue with missing the `domain.ocaml4.ml` file that I had forgotten to include in a previous PR #115.  Oops!

This PR also removes the step to extract the OCaml trunk commit hash.  This build does not use OCaml from trunk.  The commit hash was also used as a cache prefix, which is probably contributing to using a lot of cache space for the GitHub actions: 

![Screenshot 2023-12-20 at 10 51 53](https://github.com/ocaml-multicore/saturn/assets/5804945/1c0615b1-76ce-4c1b-9fbc-1565e2c995c2)

