### PR TITLE
Optimize Michael-Scott queue and remove `snapshot` mechanism

### DIFF
--- a/src_lockfree/michael_scott_queue.ml
+++ b/src_lockfree/michael_scott_queue.ml
@@ -97,11 +97,8 @@ let push { tail; _ } value =
   let (Next _ as new_node : (_, [ `Next ]) Node.t) = Node.make value in
   let old_tail = Atomic.get tail in
   let link = Node.as_atomic old_tail in
-  if Atomic.compare_and_set link Nil new_node then begin
-    if not (Atomic.compare_and_set tail old_tail new_node) then
-      let backoff = Backoff.once Backoff.default in
-      fix_tail tail new_node backoff
-  end
+  if Atomic.compare_and_set link Nil new_node then
+    Atomic.compare_and_set tail old_tail new_node |> ignore
   else
     let backoff = Backoff.once Backoff.default in
     push tail link new_node backoff

--- a/src_lockfree/michael_scott_queue.ml
+++ b/src_lockfree/michael_scott_queue.ml
@@ -27,7 +27,9 @@ type 'a t = {
 
 let create () =
   let next = Atomic.make Nil in
-  { head = Atomic.make next; tail = Atomic.make next }
+  let head = Atomic.make next |> Multicore_magic.copy_as_padded in
+  let tail = Atomic.make next |> Multicore_magic.copy_as_padded in
+  { head; tail } |> Multicore_magic.copy_as_padded
 
 let is_empty { head; _ } = Atomic.get (Atomic.get head) == Nil
 

--- a/src_lockfree/michael_scott_queue.mli
+++ b/src_lockfree/michael_scott_queue.mli
@@ -57,13 +57,3 @@ val peek : 'a t -> 'a
 val peek_opt : 'a t -> 'a option
 (** [peek_opt q] returns the first element in queue [q], or
     returns [None] if the queue is empty. *)
-
-type 'a cursor
-(** The type of cursor. *)
-
-val snapshot : 'a t -> 'a cursor
-(** Obtain a snapshot of the queue. This is a constant time operation. *)
-
-val next : 'a cursor -> ('a * 'a cursor) option
-(** [next c] returns [Some (e, c')] where [e] is the head of the queue and
-    [c'] is the tail, if the queue is non-empty. Otherwise, returns [None]. *)

--- a/src_lockfree/michael_scott_queue_node.ml
+++ b/src_lockfree/michael_scott_queue_node.ml
@@ -3,10 +3,12 @@ module Atomic = Transparent_atomic
 type ('a, _) t =
   | Nil : ('a, [> `Nil ]) t
   | Next : {
-      next : ('a, [ `Nil | `Next ]) t Atomic.t;
+      mutable next : ('a, [ `Nil | `Next ]) t;
       mutable value : 'a;
     }
       -> ('a, [> `Next ]) t
 
-let[@inline] make value = Next { next = Atomic.make Nil; value }
-let[@inline] as_atomic (Next r : ('a, [ `Next ]) t) = r.next
+let[@inline] make value = Next { next = Nil; value }
+
+external as_atomic : ('a, [ `Next ]) t -> ('a, [ `Nil | `Next ]) t Atomic.t
+  = "%identity"

--- a/src_lockfree/michael_scott_queue_node.ml
+++ b/src_lockfree/michael_scott_queue_node.ml
@@ -1,0 +1,12 @@
+module Atomic = Transparent_atomic
+
+type ('a, _) t =
+  | Nil : ('a, [> `Nil ]) t
+  | Next : {
+      next : ('a, [ `Nil | `Next ]) t Atomic.t;
+      mutable value : 'a;
+    }
+      -> ('a, [> `Next ]) t
+
+let[@inline] make value = Next { next = Atomic.make Nil; value }
+let[@inline] as_atomic (Next r : ('a, [ `Next ]) t) = r.next

--- a/test/michael_scott_queue/dune
+++ b/test/michael_scott_queue/dune
@@ -6,7 +6,13 @@
 (test
  (package saturn_lockfree)
  (name michael_scott_queue_dscheck)
- (libraries atomic dscheck alcotest backoff multicore-magic)
+ (libraries
+  atomic
+  dscheck
+  alcotest
+  backoff
+  multicore-magic
+  transparent_atomic)
  (build_if
   (and
    (>= %{ocaml_version} 5)
@@ -14,7 +20,10 @@
     (and
      (= %{arch_sixtyfour} false)
      (= %{architecture} arm)))))
- (modules michael_scott_queue michael_scott_queue_dscheck))
+ (modules
+  michael_scott_queue
+  michael_scott_queue_node
+  michael_scott_queue_dscheck))
 
 (test
  (package saturn_lockfree)

--- a/test/michael_scott_queue/dune
+++ b/test/michael_scott_queue/dune
@@ -6,7 +6,7 @@
 (test
  (package saturn_lockfree)
  (name michael_scott_queue_dscheck)
- (libraries atomic dscheck alcotest backoff)
+ (libraries atomic dscheck alcotest backoff multicore-magic)
  (build_if
   (and
    (>= %{ocaml_version} 5)

--- a/test/michael_scott_queue/michael_scott_queue_node.ml
+++ b/test/michael_scott_queue/michael_scott_queue_node.ml
@@ -1,0 +1,12 @@
+module Atomic = Transparent_atomic
+
+type ('a, _) t =
+  | Nil : ('a, [> `Nil ]) t
+  | Next : {
+      next : ('a, [ `Nil | `Next ]) t Atomic.t;
+      mutable value : 'a;
+    }
+      -> ('a, [> `Next ]) t
+
+let[@inline] make value = Next { next = Atomic.make Nil; value }
+let[@inline] as_atomic (Next r : ('a, [ `Next ]) t) = r.next


### PR DESCRIPTION
This PR optimizes the Michael-Scott queue implementation.  The main optimizations are avoiding false sharing and then optimization of the node representation, which effectively halves the length of the linked list of nodes by "inlining" the atomic into the node record and improves performance dramatically.

This PR also removes the snapshot mechanism.  The snapshot mechanism is not used in any tests in this repository.  Furthermore, the snapshot mechanism cannot be made to work (efficiently) as such with the traditional Michael-Scott queue representation where the head points to a node whose value has been taken from the queue.  That is because, to avoid space leaks, the value in the head node must be overwritten and that simply breaks the snapshot mechanism.  The previous implementation avoided this problem by using an inefficient node representation that effectively made the linked list of nodes twice as long and operations on the queue twice as slow.

Here is a run of the benchmarks on my M3 Max before the optimizations:
```json
➜  saturn git:(rewrite-bench) ✗ dune exec --release -- ./bench/main.exe -budget 1 'free Queue' | jq '[.results.[].metrics.[] | select(.name | test("over")) | {name, value}]'
[                                    
  {
    "name": "messages over time/one domain",
    "value": 25.832570841950652
  },
  {
    "name": "messages over time/1 nb adder, 1 nb taker",
    "value": 30.775546858386015
  },
  {
    "name": "messages over time/1 nb adder, 2 nb takers",
    "value": 28.61298006857959
  },
  {
    "name": "messages over time/2 nb adders, 1 nb taker",
    "value": 26.324158773037244
  },
  {
    "name": "messages over time/2 nb adders, 2 nb takers",
    "value": 26.72249173339718
  }
]
```

And here after the optimizations:
```json
➜  saturn git:(optimize-michael-scott-queue) ✗ dune exec --release -- ./bench/main.exe -budget 1 'free Queue' | jq '[.results.[].metrics.[] | select(.name | test("over")) | {name, value}]'
[                                    
  {
    "name": "messages over time/one domain",
    "value": 49.09980418998089
  },
  {
    "name": "messages over time/1 nb adder, 1 nb taker",
    "value": 98.92424842899835
  },
  {
    "name": "messages over time/1 nb adder, 2 nb takers",
    "value": 73.48287261205158
  },
  {
    "name": "messages over time/2 nb adders, 1 nb taker",
    "value": 79.05834136653924
  },
  {
    "name": "messages over time/2 nb adders, 2 nb takers",
    "value": 70.05359476527885
  }
]
```

Here is a run of the benchmarks without the inlined node representation:
```json
➜  saturn git:(optimize-michael-scott-queue) ✗ dune exec --release -- ./bench/main.exe -budget 1 'free Queue' | jq '[.results.[].metrics.[] | select(.name | test("over")) | {name, value}]'
[                                    
  {
    "name": "messages over time/one domain",
    "value": 27.799662289702503
  },
  {
    "name": "messages over time/1 nb adder, 1 nb taker",
    "value": 46.095344138917085
  },
  {
    "name": "messages over time/1 nb adder, 2 nb takers",
    "value": 42.19755884308922
  },
  {
    "name": "messages over time/2 nb adders, 1 nb taker",
    "value": 63.98353506270374
  },
  {
    "name": "messages over time/2 nb adders, 2 nb takers",
    "value": 58.21147004626938
  }
]
```

As you can see, on the `one domain` and `1 nb adder, 1 nb taker` configurations the inlined node representation is roughly twice as fast!  On the more contentious configurations, the additional cores likely both help to overcome some of the additional overhead (when not using the inlined representation) and the additional contention brings down the performance of inlined representation so the performance difference is not quite as dramatic.

You can run `cp test/michael_scott_queue/michael_scott_queue_node.ml src_lockfree` or `git reset --hard HEAD~1` to use the non-inlined node representation:

```diff
modified   src_lockfree/michael_scott_queue_node.ml
@@ -3,12 +3,10 @@ module Atomic = Transparent_atomic
 type ('a, _) t =
   | Nil : ('a, [> `Nil ]) t
   | Next : {
-      mutable next : ('a, [ `Nil | `Next ]) t;
+      next : ('a, [ `Nil | `Next ]) t Atomic.t;
       mutable value : 'a;
     }
       -> ('a, [> `Next ]) t
 
-let[@inline] make value = Next { next = Nil; value }
-
-external as_atomic : ('a, [ `Next ]) t -> ('a, [ `Nil | `Next ]) t Atomic.t
-  = "%identity"
+let[@inline] make value = Next { next = Atomic.make Nil; value }
+let[@inline] as_atomic (Next r : ('a, [ `Next ]) t) = r.next
```
