### PR TITLE
Optimize work-stealing deque

### DIFF
--- a/src/ws_deque.ml
+++ b/src/ws_deque.ml
@@ -124,7 +124,7 @@ let pop_as : type a r. a t -> (a, r) poly -> r =
     match poly with Option -> None | Value -> raise_notrace Exit
   end
 
-let pop q = pop_as q Value
+let pop_exn q = pop_as q Value
 let pop_opt q = pop_as q Option
 
 let rec steal_as : type a r. a t -> Backoff.t -> (a, r) poly -> r =
@@ -146,5 +146,5 @@ let rec steal_as : type a r. a t -> Backoff.t -> (a, r) poly -> r =
     else steal_as q (Backoff.once backoff) poly
   else match poly with Option -> None | Value -> raise_notrace Exit
 
-let steal q = steal_as q Backoff.default Value
+let steal_exn q = steal_as q Backoff.default Value
 let steal_opt q = steal_as q Backoff.default Option

--- a/src/ws_deque.ml
+++ b/src/ws_deque.ml
@@ -3,6 +3,7 @@
  * Copyright (c) 2015, KC Sivaramakrishnan <sk826@cl.cam.ac.uk>
  * Copyright (c) 2017, Nicolas ASSOUAD <nicolas.assouad@ens.fr>
  * Copyright (c) 2021, Tom Kelly <ctk21@cl.cam.ac.uk>
+ * Copyright (c) 2024, Vesa Karvonen <vesa.a.j.k@gmail.com>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -27,150 +28,136 @@
  *   https://dl.acm.org/doi/abs/10.1145/2442516.2442524
  *)
 
-module CArray = struct
-  type 'a t = 'a array
+module Atomic = Multicore_magic.Transparent_atomic
 
-  let rec log2 n = if n <= 1 then 0 else 1 + log2 (n asr 1)
+module type S = sig
+  type 'a t
 
-  let create sz v =
-    (* [sz] must be a power of two. *)
-    assert (0 < sz && sz = Int.shift_left 1 (log2 sz));
-    assert (Int.logand sz (sz - 1) == 0);
-    Array.make sz v
-
-  let size t = Array.length t [@@inline]
-  let mask t = size t - 1 [@@inline]
-
-  let index i t =
-    (* Because [size t] is a power of two, [i mod (size t)] is the same as
-       [i land (size t - 1)], that is, [i land (mask t)]. *)
-    Int.logand i (mask t)
-  [@@inline]
-
-  let get t i = Array.unsafe_get t (index i t) [@@inline]
-  let put t i v = Array.unsafe_set t (index i t) v [@@inline]
-
-  let transfer src dst top num =
-    ArrayExtra.blit_circularly (* source array and index: *)
-      src
-      (index top src) (* target array and index: *)
-      dst
-      (index top dst) (* number of elements: *)
-      num
-  [@@inline]
-
-  let grow t top bottom =
-    let sz = size t in
-    assert (bottom - top = sz);
-    let dst = create (2 * sz) (Obj.magic ()) in
-    transfer t dst top sz;
-    dst
-
-  let shrink t top bottom =
-    let sz = size t in
-    assert (bottom - top <= sz / 2);
-    let dst = create (sz / 2) (Obj.magic ()) in
-    transfer t dst top (bottom - top);
-    dst
+  val create : unit -> 'a t
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a
+  val pop_opt : 'a t -> 'a option
+  val steal : 'a t -> 'a
+  val steal_opt : 'a t -> 'a option
 end
 
-let min_size = 32
-let shrink_const = 3
+module M : S = struct
+  (** This must be a power of two. *)
+  let min_capacity = 16
 
-type 'a t = {
-  top : int Atomic.t;
-  bottom : int Atomic.t;
-  tab : 'a ref CArray.t Atomic.t;
-  mutable next_shrink : int;
-}
-
-let create () =
-  {
-    top = Atomic.make 1;
-    bottom = Atomic.make 1;
-    tab = Atomic.make (CArray.create min_size (Obj.magic ()));
-    next_shrink = 0;
+  type 'a t = {
+    top : int Atomic.t;
+    bottom : int Atomic.t;
+    top_cache : int ref;
+    mutable tab : 'a ref array;
   }
 
-let set_next_shrink q =
-  let sz = CArray.size (Atomic.get q.tab) in
-  if sz <= min_size then q.next_shrink <- 0
-  else q.next_shrink <- sz / shrink_const
+  let create () =
+    let top = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+    let tab = Array.make min_capacity (Obj.magic ()) in
+    let bottom = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+    let top_cache = ref 0 |> Multicore_magic.copy_as_padded in
+    { top; bottom; top_cache; tab } |> Multicore_magic.copy_as_padded
 
-let grow q t b =
-  Atomic.set q.tab (CArray.grow (Atomic.get q.tab) t b);
-  set_next_shrink q
+  let realloc a t b sz new_sz =
+    let new_a = Array.make new_sz (Obj.magic ()) in
+    ArrayExtra.blit_circularly a
+      (t land (sz - 1))
+      new_a
+      (t land (new_sz - 1))
+      (b - t);
+    new_a
 
-let size q =
-  let b = Atomic.get q.bottom in
-  let t = Atomic.get q.top in
-  b - t
-
-let push q v =
-  let v' = ref v in
-  let b = Atomic.get q.bottom in
-  let t = Atomic.get q.top in
-  let a = Atomic.get q.tab in
-  let size = b - t in
-  let a =
-    if size = CArray.size a then (
-      grow q t b;
-      Atomic.get q.tab)
-    else a
-  in
-  CArray.put a b v';
-  Atomic.set q.bottom (b + 1)
-
-let release ptr =
-  let res = !ptr in
-  (* we know this ptr will never be dereferenced, but want to
-     break the reference to ensure that the contents of the
-     deque array get garbage collected *)
-  ptr := Obj.magic ();
-  res
-[@@inline]
-
-let pop q =
-  if size q = 0 then raise Exit
-  else
-    let b = Atomic.get q.bottom - 1 in
-    Atomic.set q.bottom b;
-    let t = Atomic.get q.top in
-    let a = Atomic.get q.tab in
-    let size = b - t in
-    if size < 0 then (
-      (* empty queue *)
-      Atomic.set q.bottom (b + 1);
-      raise Exit)
+  let push q v =
+    let v = ref v in
+    (* Read of [bottom] by the owner simply does not require a fence as the
+       [bottom] is only mutated by the owner. *)
+    let b = Atomic.fenceless_get q.bottom in
+    let t_cache = !(q.top_cache) in
+    let a = q.tab in
+    let size = b - t_cache in
+    let capacity = Array.length a in
+    if
+      size < capacity
+      ||
+      let t = Atomic.get q.top in
+      q.top_cache := t;
+      t != t_cache
+    then begin
+      Array.unsafe_set a (b land (capacity - 1)) v;
+      Atomic.incr q.bottom
+    end
     else
-      let out = CArray.get a b in
-      if b = t then
-        (* single last element *)
-        if Atomic.compare_and_set q.top t (t + 1) then (
-          Atomic.set q.bottom (b + 1);
-          release out)
-        else (
-          Atomic.set q.bottom (b + 1);
-          raise Exit)
-      else (
-        (* non-empty queue *)
-        if q.next_shrink > size then (
-          Atomic.set q.tab (CArray.shrink a t b);
-          set_next_shrink q);
-        release out)
+      let a = realloc a t_cache b capacity (capacity lsl 1) in
+      Array.unsafe_set a (b land (Array.length a - 1)) v;
+      q.tab <- a;
+      Atomic.incr q.bottom
 
-let pop_opt q = try Some (pop q) with Exit -> None
+  type ('a, _) poly = Option : ('a, 'a option) poly | Value : ('a, 'a) poly
 
-let rec steal backoff q =
-  let t = Atomic.get q.top in
-  let b = Atomic.get q.bottom in
-  let size = b - t in
-  if size <= 0 then raise Exit
-  else
-    let a = Atomic.get q.tab in
-    let out = CArray.get a t in
-    if Atomic.compare_and_set q.top t (t + 1) then release out
-    else steal (Backoff.once backoff) q
+  let pop_as : type a r. a t -> (a, r) poly -> r =
+   fun q poly ->
+    let b = Atomic.fetch_and_add q.bottom (-1) - 1 in
+    (* Read of [top] at this point requires no fence as we simply need to ensure
+       that the read happens after updating [bottom]. *)
+    let t = Atomic.fenceless_get q.top in
+    let size = b - t in
+    if 0 < size then begin
+      let a = q.tab in
+      let capacity = Array.length a in
+      let out = Array.unsafe_get a (b land (capacity - 1)) in
+      let res = !out in
+      out := Obj.magic ();
+      if size + size + size <= capacity - min_capacity then
+        q.tab <- realloc a t b capacity (capacity lsr 1);
+      match poly with Option -> Some res | Value -> res
+    end
+    else if b = t then begin
+      (* Whether or not the [compare_and_set] below succeeds, [top_cache] can be
+         updated, because in either case [top] has been incremented. *)
+      q.top_cache := t + 1;
+      let got = Atomic.compare_and_set q.top t (t + 1) in
+      (* This write of [bottom] requires no fence.  The deque is empty and
+         remains so until the next [push]. *)
+      Atomic.fenceless_set q.bottom (b + 1);
+      if got then begin
+        let a = q.tab in
+        let out = Array.unsafe_get a (b land (Array.length a - 1)) in
+        let res = !out in
+        out := Obj.magic ();
+        match poly with Option -> Some res | Value -> res
+      end
+      else match poly with Option -> None | Value -> raise_notrace Exit
+    end
+    else begin
+      (* This write of [bottom] requires no fence.  The deque is empty and
+         remains so until the next [push]. *)
+      Atomic.fenceless_set q.bottom (b + 1);
+      match poly with Option -> None | Value -> raise_notrace Exit
+    end
 
-let steal q = steal Backoff.default q
-let steal_opt q = try Some (steal q) with Exit -> None
+  let pop q = pop_as q Value
+  let pop_opt q = pop_as q Option
+
+  let rec steal_as : type a r. a t -> Backoff.t -> (a, r) poly -> r =
+   fun q backoff poly ->
+    (* Read of [top] does not require a fence at this point, but the read of
+       [top] must happen before the read of [bottom].  The write of [top] later
+       has no effect in case we happened to read an old value of [top]. *)
+    let t = Atomic.fenceless_get q.top in
+    let b = Atomic.get q.bottom in
+    let size = b - t in
+    if 0 < size then
+      let a = q.tab in
+      let out = Array.unsafe_get a (t land (Array.length a - 1)) in
+      if Atomic.compare_and_set q.top t (t + 1) then begin
+        let res = !out in
+        out := Obj.magic ();
+        match poly with Option -> Some res | Value -> res
+      end
+      else steal_as q (Backoff.once backoff) poly
+    else match poly with Option -> None | Value -> raise_notrace Exit
+
+  let steal q = steal_as q Backoff.default Value
+  let steal_opt q = steal_as q Backoff.default Option
+end

--- a/src/ws_deque.mli
+++ b/src/ws_deque.mli
@@ -19,6 +19,8 @@ type 'a t
 val create : unit -> 'a t
 (** [create ()] returns a new empty work-stealing queue. *)
 
+exception Empty
+
 (** {1 Queue owner functions} *)
 
 val push : 'a t -> 'a -> unit

--- a/src/ws_deque.mli
+++ b/src/ws_deque.mli
@@ -25,8 +25,8 @@ val push : 'a t -> 'a -> unit
 (** [push t v] adds [v] to the front of the queue [q].
       It should only be invoked by the domain which owns the queue [q]. *)
 
-val pop : 'a t -> 'a
-(** [pop q] removes and returns the first element in queue
+val pop_exn : 'a t -> 'a
+(** [pop_exn q] removes and returns the first element in queue
       [q].It should only be invoked by the domain which owns the queue
       [q].
 
@@ -39,8 +39,8 @@ val pop_opt : 'a t -> 'a option
 
 (** {1 Stealers function} *)
 
-val steal : 'a t -> 'a
-(** [steal q] removes and returns the last element from queue
+val steal_exn : 'a t -> 'a
+(** [steal_exn q] removes and returns the last element from queue
       [q]. It should only be invoked by domain which doesn't own the
       queue [q].
 

--- a/test/ws_deque/dune
+++ b/test/ws_deque/dune
@@ -11,10 +11,12 @@
 (test
  (package saturn)
  (name ws_deque_dscheck)
- (libraries atomic dscheck alcotest backoff)
+ (libraries atomic dscheck alcotest backoff multicore-magic-dscheck)
  (build_if
   (>= %{ocaml_version} 5))
- (modules ArrayExtra ws_deque ws_deque_dscheck))
+ (modules ArrayExtra ws_deque ws_deque_dscheck)
+ (flags
+  (:standard -open Multicore_magic_dscheck)))
 
 (test
  (package saturn)

--- a/test/ws_deque/qcheck_ws_deque.ml
+++ b/test/ws_deque/qcheck_ws_deque.ml
@@ -33,7 +33,7 @@ let tests_one_producer =
           let deque = deque_of_list (l @ l') in
 
           let pop_list =
-            extract_n_of_deque deque Ws_deque.pop (List.length l')
+            extract_n_of_deque deque Ws_deque.pop_exn (List.length l')
           in
           pop_list = List.rev l'));
     (* TEST 2 - single producer no stealer :
@@ -49,7 +49,7 @@ let tests_one_producer =
           let deque = deque_of_list l in
 
           for _i = 0 to m - 1 do
-            try ignore (Ws_deque.pop deque) with Exit -> incr count
+            try ignore (Ws_deque.pop_exn deque) with Exit -> incr count
           done;
 
           !count = m - n));
@@ -77,7 +77,7 @@ let tests_one_producer_one_stealer =
           let stealer =
             Domain.spawn (fun () ->
                 let steal' deque =
-                  match Ws_deque.steal deque with
+                  match Ws_deque.steal_exn deque with
                   | value -> Some value
                   | exception Exit ->
                       Domain.cpu_relax ();
@@ -124,7 +124,7 @@ let tests_one_producer_one_stealer =
             Domain.spawn (fun () ->
                 Barrier.await barrier;
                 let steal' deque =
-                  match Ws_deque.steal deque with
+                  match Ws_deque.steal_exn deque with
                   | value -> Some value
                   | exception Exit ->
                       Domain.cpu_relax ();
@@ -175,7 +175,7 @@ let tests_one_producer_one_stealer =
           let barrier = Barrier.create 2 in
           Random.self_init ();
           let pop' deque =
-            match Ws_deque.pop deque with
+            match Ws_deque.pop_exn deque with
             | value -> Some value
             | exception Exit ->
                 Domain.cpu_relax ();
@@ -189,7 +189,7 @@ let tests_one_producer_one_stealer =
             Domain.spawn (fun () ->
                 Barrier.await barrier;
                 let steal' deque =
-                  match Ws_deque.steal deque with
+                  match Ws_deque.steal_exn deque with
                   | value -> Some value
                   | exception Exit ->
                       Domain.cpu_relax ();
@@ -242,7 +242,7 @@ let tests_one_producer_two_stealers =
 
             for i = 0 to nsteal - 1 do
               res.(i) <-
-                (match Ws_deque.steal deque with
+                (match Ws_deque.steal_exn deque with
                 | value -> Some value
                 | exception Exit ->
                     Domain.cpu_relax ();

--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -54,7 +54,7 @@ module Spec = struct
     match (c, res) with
     | Push _, Res ((Unit, _), _) -> true
     | Pop, Res ((Result (Int, Exn), _), res) -> (
-        match s with [] -> res = Error Exit | j :: _ -> res = Ok j)
+        match s with [] -> res = Error Ws_deque.Empty | j :: _ -> res = Ok j)
     | Steal, Res ((Result (Int, Exn), _), res) -> (
         match List.rev s with [] -> Result.is_error res | j :: _ -> res = Ok j)
     | _, _ -> false

--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -47,8 +47,8 @@ module Spec = struct
   let run c d =
     match c with
     | Push i -> Res (unit, Ws_deque.push d i)
-    | Pop -> Res (result int exn, protect Ws_deque.pop d)
-    | Steal -> Res (result int exn, protect Ws_deque.steal d)
+    | Pop -> Res (result int exn, protect Ws_deque.pop_exn d)
+    | Steal -> Res (result int exn, protect Ws_deque.steal_exn d)
 
   let postcond c (s : state) res =
     match (c, res) with

--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -77,10 +77,6 @@ let () =
           assume (Dom.all_interleavings_ok triple);
           repeat rep_count Dom.agree_prop_par_asym triple)
     in
-    [
-      agree_test_par_asym ~count ~name:(name ^ " parallel");
-      (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
-      Dom.neg_agree_test_par ~count ~name:(name ^ " parallel, negative");
-    ]
+    [ agree_test_par_asym ~count ~name:(name ^ " parallel") ]
   in
   Stm_run.run ~name:"Saturn.Ws_deque" ~make_domain (module Spec) |> exit

--- a/test/ws_deque/test_ws_deque.ml
+++ b/test/ws_deque/test_ws_deque.ml
@@ -3,7 +3,7 @@ open Saturn.Work_stealing_deque
 
 let test_empty () =
   let q = create () in
-  match pop q with
+  match pop_exn q with
   | exception Exit -> print_string "test_exit: ok\n"
   | _ -> assert false
 
@@ -12,9 +12,9 @@ let test_push_and_pop () =
   push q 1;
   push q 10;
   push q 100;
-  assert (pop q = 100);
-  assert (pop q = 10);
-  assert (pop q = 1);
+  assert (pop_exn q = 100);
+  assert (pop_exn q = 10);
+  assert (pop_exn q = 1);
   print_string "test_push_and_pop: ok\n"
 
 let test_push_and_steal () =
@@ -25,7 +25,7 @@ let test_push_and_steal () =
   let domains =
     Array.init 3 (fun _ ->
         Domain.spawn (fun _ ->
-            let v = steal q in
+            let v = steal_exn q in
             assert (v = 1 || v = 10 || v = 100)))
   in
   Array.iter Domain.join domains;
@@ -64,7 +64,7 @@ let test_concurrent_workload () =
           pushed := x :: !pushed;
           decr n
         and pop () =
-          match pop q with
+          match pop_exn q with
           | exception Exit ->
               Domain.cpu_relax ();
               false
@@ -89,7 +89,7 @@ let test_concurrent_workload () =
     Array.init thieves (fun i ->
         Domain.spawn (fun () ->
             let steal () =
-              match steal q with
+              match steal_exn q with
               | exception Exit -> Domain.cpu_relax ()
               | x -> stolen.(i) <- x :: stolen.(i)
             in

--- a/test/ws_deque/test_ws_deque.ml
+++ b/test/ws_deque/test_ws_deque.ml
@@ -4,7 +4,7 @@ open Saturn.Work_stealing_deque
 let test_empty () =
   let q = create () in
   match pop_exn q with
-  | exception Exit -> print_string "test_exit: ok\n"
+  | exception Empty -> print_string "test_exit: ok\n"
   | _ -> assert false
 
 let test_push_and_pop () =
@@ -65,7 +65,7 @@ let test_concurrent_workload () =
           decr n
         and pop () =
           match pop_exn q with
-          | exception Exit ->
+          | exception Empty ->
               Domain.cpu_relax ();
               false
           | x ->
@@ -90,7 +90,7 @@ let test_concurrent_workload () =
         Domain.spawn (fun () ->
             let steal () =
               match steal_exn q with
-              | exception Exit -> Domain.cpu_relax ()
+              | exception Empty -> Domain.cpu_relax ()
               | x -> stolen.(i) <- x :: stolen.(i)
             in
 

--- a/test/ws_deque/ws_deque_dscheck.ml
+++ b/test/ws_deque/ws_deque_dscheck.ml
@@ -2,7 +2,7 @@ let drain_remaining queue =
   let remaining = ref 0 in
   (try
      while true do
-       Ws_deque.pop queue |> ignore;
+       Ws_deque.pop_exn queue |> ignore;
        remaining := !remaining + 1
      done
    with _ -> ());
@@ -21,7 +21,7 @@ let owner_stealer () =
             Ws_deque.push queue 0
           done;
           for _ = 1 to total_items / 2 do
-            match Ws_deque.pop queue with
+            match Ws_deque.pop_exn queue with
             | exception _ -> ()
             | _ -> popped := !popped + 1
           done);
@@ -29,7 +29,7 @@ let owner_stealer () =
       (* stealer *)
       Atomic.spawn (fun () ->
           for _ = 1 to total_items / 2 do
-            match Ws_deque.steal queue with
+            match Ws_deque.steal_exn queue with
             | exception _ -> ()
             | _ -> popped := !popped + 1
           done);
@@ -50,7 +50,7 @@ let popper_stealer () =
       (* stealers *)
       let popped = ref 0 in
       let stealer () =
-        match Ws_deque.steal queue with
+        match Ws_deque.steal_exn queue with
         | exception _ -> ()
         | _ -> popped := !popped + 1
       in


### PR DESCRIPTION
This PR optimizes the work-stealing deque.

The graphs on current-bench show the progress of optimizing the work-stealing deque quite nicely:

![image](https://github.com/ocaml-multicore/saturn/assets/5804945/db558fb1-c736-4f95-8b52-6a12701ed10d)

Here is a run of the benchmarks on my M3 Max before the optimizations:
```json
➜  saturn git:(rewrite-bench) ✗ dune exec --release -- ./bench/main.exe -budget 1 'Work' | jq '[.results.[].metrics.[] | select(.name | test("over")) | {name, value}]'
[                                    
  {
    "name": "spawns over time/1 worker",
    "value": 49.86378542204304
  },
  {
    "name": "spawns over time/2 workers",
    "value": 44.30827252087946
  },
  {
    "name": "spawns over time/4 workers",
    "value": 84.66239655969726
  },
  {
    "name": "spawns over time/8 workers",
    "value": 177.69250680679536
  }
]
```

Here is a run after the optimizations:
```json
➜  saturn git:(optimize-ws-deque) ✗ dune exec --release -- ./bench/main.exe -budget 1 'Work' | jq '[.results.[].metrics.[] | select(.name | test("over")) | {name, value}]'
[                                     
  {
    "name": "spawns over time/1 worker",
    "value": 61.20210013480126
  },
  {
    "name": "spawns over time/2 workers",
    "value": 121.42420051856216
  },
  {
    "name": "spawns over time/4 workers",
    "value": 235.72974008156237
  },
  {
    "name": "spawns over time/8 workers",
    "value": 428.2572470382373
  }
]
```

General approach:
1. Add benchmark(s). In this case the benchmark simulates a scheduler running parallel fibonacci.
2. Avoid false sharing.  With false sharing there will be too much noise to get any other useful optimizations done.  In this case the top and bottom indices and the root record had to be padded to avoid false sharing.  This already gave a big performance improvement.
3. Avoid other forms of contention.  Contention tends to mask any benefits from further optimizations. In this case there wasn't much of that except for avoiding some unnecessary loads and stores.  With parallel data structures, any reads and writes of shared locations (atomic or non-atomic) should be viewed with suspicion.
4. Usual micro-optimizations such as avoiding float array pessimization, indirections, costly operations, avoiding dependency chains, avoiding unnecessary work, avoiding unnecessary fences, making the common case fast (at the expense of less common case), ... Unless main contention issues are addressed micro-optimizations are difficult to make as noise and stalls from contention mask the improvements.