### PR TITLE
Tweak treiber stack

### DIFF
--- a/test/treiber_stack/dune
+++ b/test/treiber_stack/dune
@@ -6,7 +6,7 @@
 (test
  (package saturn_lockfree)
  (name treiber_stack_dscheck)
- (libraries atomic dscheck alcotest backoff)
+ (libraries atomic dscheck alcotest backoff multicore-magic)
  (enabled_if
   (not
    (and


### PR DESCRIPTION
This PR tweaks the Treiber stack implementation using a GADT to avoid duplicating the shared code for `pop` and `pop_opt` reducing size of generated code slightly.  Also implements a few other usual tweaks such as adding padding to avoid false sharing.