### PR TITLE
Fix cycle dependency in skiplist tests

### DIFF
--- a/test/skiplist/dune
+++ b/test/skiplist/dune
@@ -18,7 +18,7 @@
  (name qcheck_skiplist)
  (modules qcheck_skiplist)
  (libraries
-  saturn
+  saturn_lockfree
   barrier
   qcheck
   qcheck-core
@@ -30,4 +30,4 @@
  (package saturn_lockfree)
  (name stm_skiplist)
  (modules stm_skiplist)
- (libraries saturn qcheck-core qcheck-stm.stm stm_run))
+ (libraries saturn_lockfree qcheck-core qcheck-stm.stm stm_run))

--- a/test/skiplist/qcheck_skiplist.ml
+++ b/test/skiplist/qcheck_skiplist.ml
@@ -1,5 +1,5 @@
 module Skiplist = struct
-  include Saturn.Skiplist
+  include Saturn_lockfree.Skiplist
 
   let try_add s k = try_add s k ()
 end

--- a/test/skiplist/stm_skiplist.ml
+++ b/test/skiplist/stm_skiplist.ml
@@ -2,7 +2,7 @@ open QCheck
 open STM
 
 module Skiplist = struct
-  include Saturn.Skiplist
+  include Saturn_lockfree.Skiplist
 
   type nonrec 'a t = ('a, unit) t
 


### PR DESCRIPTION
 The skiplist tests required the `saturn` library while being part of the `saturn_lockfree` package, likely creating a circular dependency and preventing successful installation when running opam install . --with-test. This patch resolves that issue.